### PR TITLE
Enable envelope-level fuzzing and spec-correct notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+cleints/
 # C extensions
 *.so
 servers

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 cleints/
+servers/
+sdks/
 # C extensions
 *.so
 servers

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ The MCP Fuzzer uses a modular architecture with clear separation of concerns:
   - `aggressive/`: Aggressive data generation (malicious/malformed inputs)
     - `tool_strategy.py`: Aggressive tool argument strategies (injections, overflows)
     - `protocol_type_strategy.py`: Aggressive protocol message strategies
+- **`safety.py`**: Argument-level safety filter (recursive sanitization, URL/command blocking, adds safety metadata via `_meta`)
+- **`system_blocker.py`**: System-level command blocker (PATH shim with fake executables to prevent opening browsers/apps; provides `start_system_blocking()`, `stop_system_blocking()`, and `get_blocked_operations()`)
 
 ### Architecture Flow
 

--- a/mcp_fuzzer/client.py
+++ b/mcp_fuzzer/client.py
@@ -296,16 +296,20 @@ class UnifiedMCPFuzzerClient:
 
     async def _send_progress_notification(self, data: Dict[str, Any]) -> Any:
         """Send a progress notification as JSON-RPC notification (no id)."""
-        await self.transport.send_notification(
-            "notifications/progress", data.get("params", {})
-        )
+        params = data.get("params", {})
+        if not isinstance(params, dict):
+            logging.debug("Non-dict params for progress notification; coercing to {}")
+            params = {}
+        await self.transport.send_notification("notifications/progress", params)
         return {"status": "notification_sent"}
 
     async def _send_cancel_notification(self, data: Dict[str, Any]) -> Any:
         """Send a cancel notification as JSON-RPC notification (no id)."""
-        await self.transport.send_notification(
-            "notifications/cancelled", data.get("params", {})
-        )
+        params = data.get("params", {})
+        if not isinstance(params, dict):
+            logging.debug("Non-dict params for cancel notification; coercing to {}")
+            params = {}
+        await self.transport.send_notification("notifications/cancelled", params)
         return {"status": "notification_sent"}
 
     async def _send_list_resources_request(self, data: Dict[str, Any]) -> Any:

--- a/mcp_fuzzer/client.py
+++ b/mcp_fuzzer/client.py
@@ -295,15 +295,15 @@ class UnifiedMCPFuzzerClient:
         return await self.transport.send_request("initialize", data.get("params", {}))
 
     async def _send_progress_notification(self, data: Dict[str, Any]) -> Any:
-        """Send a progress notification."""
-        await self.transport.send_request(
+        """Send a progress notification as JSON-RPC notification (no id)."""
+        await self.transport.send_notification(
             "notifications/progress", data.get("params", {})
         )
         return {"status": "notification_sent"}
 
     async def _send_cancel_notification(self, data: Dict[str, Any]) -> Any:
-        """Send a cancel notification."""
-        await self.transport.send_request(
+        """Send a cancel notification as JSON-RPC notification (no id)."""
+        await self.transport.send_notification(
             "notifications/cancelled", data.get("params", {})
         )
         return {"status": "notification_sent"}

--- a/mcp_fuzzer/fuzzer/protocol_fuzzer.py
+++ b/mcp_fuzzer/fuzzer/protocol_fuzzer.py
@@ -57,12 +57,15 @@ class ProtocolFuzzer:
 
                 if self.transport:
                     try:
-                        server_response = await self.transport.send_request(fuzz_data)
-                        logging.debug(f"Server accepted fuzz data for {protocol_type}")
+                        # Send envelope exactly as generated
+                        server_response = await self.transport.send_raw(fuzz_data)
+                        logging.debug(
+                            f"Server accepted fuzzed envelope for {protocol_type}"
+                        )
                     except Exception as server_exception:
                         server_error = str(server_exception)
                         logging.debug(
-                            f"Server rejected fuzz data (expected): {server_exception}"
+                            "Server rejected fuzzed envelope: %s", server_exception
                         )
 
                 # Create the result entry

--- a/mcp_fuzzer/transport.py
+++ b/mcp_fuzzer/transport.py
@@ -31,6 +31,23 @@ class TransportProtocol(ABC):
         """Send a JSON-RPC request and return the response."""
         pass
 
+    @abstractmethod
+    async def send_raw(self, payload: Dict[str, Any]) -> Any:
+        """
+        Send a raw JSON-RPC payload AS-IS.
+        Do not rewrite jsonrpc/id/method/params.
+        """
+        pass
+
+    @abstractmethod
+    async def send_notification(
+        self, method: str, params: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """
+        Send a JSON-RPC notification (no id, no response expected).
+        """
+        pass
+
     async def get_tools(self) -> List[Dict[str, Any]]:
         """Get the list of tools from the server."""
         try:
@@ -149,6 +166,41 @@ class HTTPTransport(TransportProtocol):
             # Return the result if it exists, otherwise return the full data
             return data.get("result", data)
 
+    async def send_raw(self, payload: Dict[str, Any]) -> Any:
+        """Send a raw JSON-RPC payload via HTTP without altering fields."""
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(self.url, json=payload, headers=self.headers)
+            response.raise_for_status()
+            try:
+                data = response.json()
+            except json.JSONDecodeError:
+                # Attempt simple SSE-like parse for data: lines
+                for line in response.text.splitlines():
+                    if line.startswith("data:"):
+                        data = json.loads(line[len("data:") :].strip())
+                        break
+                else:
+                    raise
+            if isinstance(data, dict) and "error" in data:
+                raise Exception(f"Server error: {data['error']}")
+            if isinstance(data, dict):
+                return data.get("result", data)
+            return data
+
+    async def send_notification(
+        self, method: str, params: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Send a JSON-RPC notification (no id) via HTTP."""
+        payload = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params or {},
+        }
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            # Fire-and-forget semantics; still POST to endpoint
+            response = await client.post(self.url, json=payload, headers=self.headers)
+            response.raise_for_status()
+
 
 class SSETransport(TransportProtocol):
     """Server-Sent Events transport for MCP servers."""
@@ -191,6 +243,41 @@ class SSETransport(TransportProtocol):
                         continue
 
             raise Exception("No valid SSE response received")
+
+    async def send_raw(self, payload: Dict[str, Any]) -> Any:
+        """
+        Send a raw JSON-RPC payload via SSE endpoint (POST then parse data: lines).
+        """
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(self.url, json=payload, headers=self.headers)
+            response.raise_for_status()
+            for line in response.text.splitlines():
+                if line.startswith("data:"):
+                    data = json.loads(line[len("data:") :].strip())
+                    if "error" in data:
+                        raise Exception(f"Server error: {data['error']}")
+                    return data.get("result", data)
+            # Some servers may respond with plain JSON
+            try:
+                data = response.json()
+                if "error" in data:
+                    raise Exception(f"Server error: {data['error']}")
+                return data.get("result", data)
+            except json.JSONDecodeError:
+                pass
+            raise Exception("No valid SSE response received")
+
+    async def send_notification(
+        self, method: str, params: Optional[Dict[str, Any]] = None
+    ) -> None:
+        payload = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params or {},
+        }
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(self.url, json=payload, headers=self.headers)
+            response.raise_for_status()
 
 
 class StdioTransport(TransportProtocol):
@@ -284,6 +371,71 @@ class StdioTransport(TransportProtocol):
             logging.error("Process stderr: %s", stderr_text)
             raise
 
+    async def send_raw(self, payload: Dict[str, Any]) -> Any:
+        """Send a raw JSON-RPC payload via stdio."""
+        process = await asyncio.create_subprocess_exec(
+            *shlex.split(self.command),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        stdin_data = json.dumps(payload).encode() + b"\n"
+        stdout, stderr = await asyncio.wait_for(
+            process.communicate(stdin_data), timeout=self.timeout
+        )
+
+        if process.returncode != 0:
+            logging.error(
+                "Process failed with return code %d: %s",
+                process.returncode,
+                stderr.decode(),
+            )
+            raise Exception(f"Process failed: {stderr.decode()}")
+
+        stdout_text = stdout.decode()
+        try:
+            lines = stdout_text.strip().split("\n")
+            main_response = None
+            for line in lines:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    json_obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(json_obj, dict) and (
+                    "result" in json_obj or "error" in json_obj
+                ):
+                    main_response = json_obj
+                    break
+            if main_response is None:
+                raise json.JSONDecodeError("No main response found", stdout_text, 0)
+            if "error" in main_response:
+                raise Exception(f"Server error: {main_response['error']}")
+            return main_response.get("result", main_response)
+        except json.JSONDecodeError:
+            logging.error("Failed to parse response as JSON: %s", stdout_text)
+            raise
+
+    async def send_notification(
+        self, method: str, params: Optional[Dict[str, Any]] = None
+    ) -> None:
+        payload = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params or {},
+        }
+        process = await asyncio.create_subprocess_exec(
+            *shlex.split(self.command),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdin_data = json.dumps(payload).encode() + b"\n"
+        await asyncio.wait_for(process.communicate(stdin_data), timeout=self.timeout)
+
 
 class WebSocketTransport(TransportProtocol):
     """WebSocket-based transport for MCP servers."""
@@ -320,6 +472,34 @@ class WebSocketTransport(TransportProtocol):
                 return data.get("result", data)
             except asyncio.TimeoutError:
                 raise Exception("WebSocket request timed out")
+
+    async def send_raw(self, payload: Dict[str, Any]) -> Any:
+        """Send a raw JSON-RPC payload via WebSocket."""
+        async with websockets.connect(self.url) as websocket:
+            await websocket.send(json.dumps(payload))
+            try:
+                response = await asyncio.wait_for(
+                    websocket.recv(), timeout=self.timeout
+                )
+                data = json.loads(response)
+                if isinstance(data, dict) and "error" in data:
+                    raise Exception(f"Server error: {data['error']}")
+                if isinstance(data, dict):
+                    return data.get("result", data)
+                return data
+            except asyncio.TimeoutError:
+                raise Exception("WebSocket request timed out")
+
+    async def send_notification(
+        self, method: str, params: Optional[Dict[str, Any]] = None
+    ) -> None:
+        payload = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params or {},
+        }
+        async with websockets.connect(self.url) as websocket:
+            await websocket.send(json.dumps(payload))
 
 
 def create_transport(protocol: str, endpoint: str, **kwargs) -> TransportProtocol:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -340,8 +340,28 @@ class TestUnifiedMCPFuzzerClient(unittest.IsolatedAsyncioTestCase):
         result = await self.client._send_progress_notification(data)
 
         self.assertEqual(result, {"status": "notification_sent"})
+        # Ensure request path is not used for notifications
+        self.mock_transport.send_request.assert_not_called()
         self.mock_transport.send_notification.assert_called_with(
             "notifications/progress", {"progress": 50}
+        )
+
+    async def test_send_cancel_notification(self):
+        """Test sending cancel notification."""
+        data = {
+            "jsonrpc": "2.0",
+            "method": "notifications/cancelled",
+            "params": {"requestId": 123},
+        }
+
+        self.mock_transport.send_notification.return_value = None
+
+        result = await self.client._send_cancel_notification(data)
+
+        self.assertEqual(result, {"status": "notification_sent"})
+        self.mock_transport.send_request.assert_not_called()
+        self.mock_transport.send_notification.assert_called_with(
+            "notifications/cancelled", {"requestId": 123}
         )
 
     @patch("mcp_fuzzer.client.logging")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -22,6 +22,7 @@ class TestUnifiedMCPFuzzerClient(unittest.IsolatedAsyncioTestCase):
         # Ensure awaited calls are awaitable
         self.mock_transport.call_tool = AsyncMock()
         self.mock_transport.send_request = AsyncMock()
+        self.mock_transport.send_notification = AsyncMock()
         self.mock_transport.get_tools = AsyncMock()
         self.mock_auth_manager = MagicMock()
         self.client = UnifiedMCPFuzzerClient(
@@ -333,13 +334,13 @@ class TestUnifiedMCPFuzzerClient(unittest.IsolatedAsyncioTestCase):
             "params": {"progress": 50},
         }
 
-        mock_response = {"result": "success"}
-        self.mock_transport.send_request.return_value = mock_response
+        # Notification should not use send_request; ensure send_notification is called
+        self.mock_transport.send_notification.return_value = None
 
         result = await self.client._send_progress_notification(data)
 
         self.assertEqual(result, {"status": "notification_sent"})
-        self.mock_transport.send_request.assert_called_with(
+        self.mock_transport.send_notification.assert_called_with(
             "notifications/progress", {"progress": 50}
         )
 

--- a/tests/test_protocol_fuzzer.py
+++ b/tests/test_protocol_fuzzer.py
@@ -19,7 +19,8 @@ class TestProtocolFuzzer(unittest.IsolatedAsyncioTestCase):
         """Set up test fixtures."""
         # Create a mock transport for testing
         self.mock_transport = AsyncMock()
-        self.mock_transport.send_request.return_value = {"result": "test_response"}
+        # ProtocolFuzzer now uses send_raw to transmit envelope-level fuzzed messages
+        self.mock_transport.send_raw.return_value = {"result": "test_response"}
         self.fuzzer = ProtocolFuzzer(self.mock_transport)
 
     def test_init(self):
@@ -87,7 +88,7 @@ class TestProtocolFuzzer(unittest.IsolatedAsyncioTestCase):
     async def test_fuzz_protocol_type_transport_exception(self, mock_logging):
         """Test handling of transport exceptions."""
         # Set up transport to raise an exception
-        self.mock_transport.send_request.side_effect = Exception("Transport error")
+        self.mock_transport.send_raw.side_effect = Exception("Transport error")
 
         results = await self.fuzzer.fuzz_protocol_type("InitializeRequest", runs=2)
 

--- a/tests/test_protocol_fuzzer.py
+++ b/tests/test_protocol_fuzzer.py
@@ -96,6 +96,8 @@ class TestProtocolFuzzer(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(results), 2)
         for result in results:
             self.assertIn("server_error", result)
+        # Ensure send_raw was attempted for each run
+        self.assertEqual(self.mock_transport.send_raw.await_count, 2)
 
     @patch("mcp_fuzzer.fuzzer.protocol_fuzzer.logging")
     async def test_fuzz_all_protocol_types(self, mock_logging):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -33,6 +33,12 @@ class TestTransportProtocol(unittest.IsolatedAsyncioTestCase):
             async def send_request(self, method, params=None):
                 return {"result": "test_response"}
 
+            async def send_raw(self, payload):
+                return {"result": "test_response"}
+
+            async def send_notification(self, method, params=None):
+                return None
+
         self.transport = TestTransport()
 
     async def test_get_tools_success(self):


### PR DESCRIPTION
fixes #37 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Transports now support sending raw envelopes and fire-and-forget notifications; progress and cancel updates use non-blocking notifications; protocol fuzzing sends complete envelopes with clearer logging.

- Documentation
  - Added docs for an argument-level safety filter and a system-level command blocker, describing capabilities and usage.

- Chores
  - Updated repository ignore rules to include temporary/sdk directories.

- Tests
  - Expanded tests to cover raw payload and notification paths and related client behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->