### PR TITLE
Use pytest-asyncio for unittest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ per-file-ignores = { "tests/**" = ["F401", "F841"] }
 [tool.pytest.ini_options]
 addopts = "-q --maxfail=1 --disable-warnings --cov=mcp_fuzzer --cov-report=term-missing --cov-report=xml"
 testpaths = ["tests"]
+asyncio_mode = "auto"
 
 [tool.coverage.run]
 branch = true

--- a/tests/test_streamable_http.py
+++ b/tests/test_streamable_http.py
@@ -1,3 +1,5 @@
+"""Async tests use pytest-asyncio."""
+
 import asyncio
 import types
 from typing import Any, Dict, List, Optional
@@ -8,12 +10,6 @@ from mcp_fuzzer.transport.streamable_http import (
     CONTENT_TYPE,
 )
 from mcp_fuzzer.config import DEFAULT_PROTOCOL_VERSION
-
-
-# Force anyio to use asyncio backend for these tests (no trio dependency required)
-@pytest.fixture
-def anyio_backend():
-    return "asyncio"
 
 
 class _DummyResponse:
@@ -80,7 +76,7 @@ class _FakeAsyncClient:
         return self._responses.pop(0)
 
 
-@pytest.mark.anyio("asyncio")
+@pytest.mark.asyncio
 async def test_streamable_http_json_initialize(monkeypatch):
     # Arrange: first call returns JSON initialize with session header
     init_result = {"protocolVersion": DEFAULT_PROTOCOL_VERSION, "ok": True}
@@ -122,7 +118,7 @@ async def test_streamable_http_json_initialize(monkeypatch):
     assert last_headers.get("mcp-protocol-version") == DEFAULT_PROTOCOL_VERSION
 
 
-@pytest.mark.anyio("asyncio")
+@pytest.mark.asyncio
 async def test_streamable_http_sse_response(monkeypatch):
     # Arrange: SSE data with one JSON-RPC response containing result
     sse_lines = [

--- a/tests/test_streamable_http.py
+++ b/tests/test_streamable_http.py
@@ -5,6 +5,9 @@ import types
 from typing import Any, Dict, List, Optional
 
 import pytest
+
+# Skip this module if pytest-asyncio is not available to avoid failing runs
+pytest.importorskip("pytest_asyncio")
 from mcp_fuzzer.transport.streamable_http import (
     StreamableHTTPTransport,
     CONTENT_TYPE,

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ description = Run unit tests with coverage
 deps =
     pytest
     pytest-cov
+    pytest-asyncio
 commands =
     pytest -vv --cov=mcp_fuzzer --cov-report=term-missing
 basepython = python3


### PR DESCRIPTION
fixes #62 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Migrated async tests to use pytest-asyncio and added guards to skip when unavailable, improving async test reliability.
  * Updated test markers to rely on pytest-asyncio’s event loop handling.

* **Chores**
  * Enabled automatic asyncio mode in test configuration and added asyncio test dependency for CI/test environments.

No user-facing changes; functionality and public APIs remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->