### PR TITLE
fix: dynamically fetch version from package metadata and update test

### DIFF
--- a/mcp_fuzzer/reports/output_protocol.py
+++ b/mcp_fuzzer/reports/output_protocol.py
@@ -15,12 +15,19 @@ from typing import Any, Dict, List, Optional
 
 from ..exceptions import ValidationError
 
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    TOOL_VERSION = version("mcp-fuzzer")
+except PackageNotFoundError:
+    TOOL_VERSION = "unknown"
+
 
 class OutputProtocol:
     """Handles standardized output format with mini-protocol for MCP Fuzzer."""
 
     PROTOCOL_VERSION = "1.0.0"
-    TOOL_VERSION = "0.1.6"  # TODO: Get from package version
+    TOOL_VERSION = TOOL_VERSION
 
     # Output types
     OUTPUT_TYPES = {

--- a/mcp_fuzzer/reports/reporter.py
+++ b/mcp_fuzzer/reports/reporter.py
@@ -26,6 +26,13 @@ from .formatters import (
 from .output_protocol import OutputManager
 from .safety_reporter import SafetyReporter
 
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    fuzzer_version = version("mcp-fuzzer")
+except PackageNotFoundError:
+    fuzzer_version = "unknown"
+
 
 class FuzzerReporter:
     """Centralized reporter for all MCP Fuzzer output and reporting."""
@@ -100,7 +107,7 @@ class FuzzerReporter:
             "endpoint": endpoint,
             "runs": runs,
             "runs_per_type": runs_per_type,
-            "fuzzer_version": "1.0.0",  # TODO: Get from package
+            "fuzzer_version": fuzzer_version,
         }
 
     def add_tool_results(self, tool_name: str, results: List[Dict[str, Any]]):

--- a/tests/unit/reports/test_output_protocol.py
+++ b/tests/unit/reports/test_output_protocol.py
@@ -12,6 +12,13 @@ import pytest
 
 from mcp_fuzzer.reports.output_protocol import OutputProtocol, OutputManager
 
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    expected_version = version("mcp-fuzzer")
+except PackageNotFoundError:
+    expected_version = "unknown"
+
 
 class TestOutputProtocol:
     """Test cases for OutputProtocol class."""
@@ -26,7 +33,7 @@ class TestOutputProtocol:
         output = self.protocol.create_base_output("fuzzing_results", data)
 
         assert output["protocol_version"] == "1.0.0"
-        assert output["tool_version"] == "0.1.6"
+        assert output["tool_version"] == expected_version
         assert output["session_id"] == "test-session-123"
         assert output["output_type"] == "fuzzing_results"
         assert output["data"] == data


### PR DESCRIPTION
Part of #102 

Fixed TODOs that required fetching the version dynamically from the package instead of hardcoding it.

### Details
- Updated `mcp_fuzzer/reports/reporter.py` to use `importlib.metadata.version('mcp-fuzzer')`
- Updated `mcp_fuzzer/reports/output_protocol.py` similarly
- Added fallback to `"unknown"` if the package isn’t installed

### Verification
Tested locally after installing the package in editable mode:

`python -c "from importlib.metadata import version; print(version('mcp-fuzzer'))"`

#### Output:
`0.2.1`
Both reporter and output protocol now correctly report the package version. And all tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated version reporting to dynamically retrieve the installed package version instead of using hardcoded values. The tool now displays the correct version number and gracefully falls back to "unknown" if version information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->