### PR TITLE
docs: align docs with current code

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ If your server conforms to the [MCP schema](https://github.com/modelcontextproto
 
 ### Why Choose MCP Server Fuzzer?
 
-- Safety First: Built-in safety system prevents dangerous operations
+- Safety First: Optional system-level safety controls (command blocking, sandboxing, network policy)
 - High Performance: Asynchronous execution with configurable concurrency
 - Beautiful Output: Rich, colorized terminal output with detailed reporting
 - Flexible Configuration: CLI args, YAML configs, environment variables
 - Comprehensive Reporting: Multiple output formats (JSON, CSV, HTML, Markdown)
-- Production Ready: PATH shims, sandbox defaults, and CI-friendly controls
+- Production Ready: PATH shims, sandbox controls, and CI-friendly defaults
 - Intelligent Testing: Hypothesis-based data generation with custom strategies
 - More Than Conformance: Goes beyond the checks in [modelcontextprotocol/conformance](https://github.com/modelcontextprotocol/conformance) with fuzzing, reporting, and safety tooling
 
@@ -60,7 +60,7 @@ It does **not** use instrumentation-based fuzzing (no coverage or binary/source 
 MCP Server Fuzzer is designed for easy extension while keeping CLI usage simple:
 
 - **Custom Transports**: Add support for new protocols via config or self-registration (see [docs/transport/custom-transports.md](docs/transport/custom-transports.md)).
-- **Pluggable Safety**: Swap safety providers for custom filtering rules.
+- **Pluggable Safety**: Swap safety providers for custom safety rules.
 - **Injectable Components**: Advanced users can inject custom clients/reporters for testing or plugins.
 
 The modularity improvements (dependency injection, registries) make it maintainer-friendly without complicating the core CLI experience.
@@ -150,6 +150,10 @@ mcp-fuzzer --mode protocol --protocol-type InitializeRequest --protocol sse --en
 ```bash
 # Two-phase fuzzing (realistic + aggressive)
 mcp-fuzzer --mode all --phase both --protocol http --endpoint http://localhost:8000
+
+# Aggressive protocol fuzzing (protocol phase is separate from --phase)
+mcp-fuzzer --mode protocol --protocol-type InitializeRequest --protocol-phase aggressive \
+  --protocol http --endpoint http://localhost:8000
 
 # With safety system enabled
 mcp-fuzzer --mode tools --enable-safety-system --safety-report
@@ -410,21 +414,21 @@ mcp-fuzzer --timeout 120 --process-retry-count 5 --process-retry-delay 2.0
 |---------|-------------|
 | Two-Phase Fuzzing | Realistic testing + aggressive security testing |
 | Multi-Protocol Support | HTTP, SSE, Stdio, and StreamableHTTP transports |
-| Built-in Safety | Pattern-based filtering, sandboxing, and PATH shims |
+| Built-in Safety | System command blocking, optional sandboxing, and safety reports |
 | Intelligent Testing | Hypothesis-based data generation with custom strategies |
 | Rich Reporting | Detailed output with exception tracking and safety reports |
 | Multiple Output Formats | JSON, CSV, HTML, Markdown, and XML export options |
 | Flexible Configuration | CLI args, YAML configs, environment variables |
 | Asynchronous Execution | Efficient concurrent fuzzing with configurable limits |
-| Comprehensive Monitoring | Process watchdog, timeout handling, and resource management |
+| Comprehensive Monitoring | Process watchdog and timeout handling for subprocesses |
 | Authentication Support | API keys, basic auth, OAuth, and custom providers |
-| Performance Metrics | Built-in benchmarking and performance analysis |
+| Stateful Sequences | Optional learned protocol sequences for realistic flows |
 | Schema Validation | Automatic MCP protocol compliance checking |
 
 ### Performance
 
-- Concurrent Operations: Up to 20 simultaneous fuzzing tasks
-- Memory Efficient: Streaming responses and configurable resource limits
+- Concurrent Operations: Configurable concurrency limits per run
+- Memory Efficient: Async I/O with streaming where supported
 - Fast Execution: Optimized async I/O and connection pooling
 - Scalable: Configurable timeouts and retry mechanisms
 

--- a/docs/SECURITY_CI.md
+++ b/docs/SECURITY_CI.md
@@ -11,8 +11,8 @@ The e2e test script can be safely run in GitHub Actions with the following secur
 ### 1. **Safety System Integration**
 - **Command Blocking**: Prevents execution of dangerous system commands when `--enable-safety-system` is set
 - **Filesystem Sandboxing**: Constrains file paths when `--fs-root` (or `MCP_FUZZER_FS_ROOT`) is set
-- **Process Management**: Stdio servers run as managed subprocesses with watchdog timeouts
-- **Network Restrictions**: Available via `--no-network` + `--allow-host` (not enabled by default)
+- **Process Management**: Stdio servers run as managed subprocesses with watchdog timeouts when tests launch server processes
+- **Network Restrictions**: Enforced when `--no-network` is enabled, with optional host exceptions via `--allow-host`
 
 ### 2. **CI Environment Protections**
 - **Ephemeral Runners**: GitHub Actions runners are destroyed after each run
@@ -20,9 +20,9 @@ The e2e test script can be safely run in GitHub Actions with the following secur
 - **Resource Limits**: GitHub enforces CPU, memory, and time limits
 - **Artifact Isolation**: Test results are isolated and controlled
 
-### 3. **Built-in Safety Features**
+### 3. **Flag-Driven Safety Features**
 
-#### Command Blocking (Active)
+#### Command Blocking (When Enabled)
 ```bash
 # Blocked commands include:
 xdg-open, open, start, firefox, chrome, chromium
@@ -72,7 +72,7 @@ jobs:
         MCP_FUZZER_TIMEOUT: '30'
       run: |
         chmod +x tests/e2e/test_everything_server_docker.sh
-        ./tests/e2e/test_everything_server_docker.sh
+        ./tests/e2e/test_everything_server_docker.sh --enable-safety-system
 
     - name: Upload results
       uses: actions/upload-artifact@v4
@@ -139,12 +139,12 @@ MCP_FUZZER_ICON_THEME=ascii
 
 ## 🎯 Conclusion
 
-**The e2e test script is SAFE for GitHub Actions execution** with:
+**The e2e test script is SAFE for GitHub Actions execution when recommended safety flags are enabled**, including:
 
-- ✅ **Comprehensive safety system** preventing dangerous operations
+- ✅ **Flag-driven safety controls** (command blocking, sandboxing, and network policy)
 - ✅ **CI environment isolation** providing additional security layer
 - ✅ **Resource controls** preventing resource exhaustion
 - ✅ **Artifact isolation** controlling data exposure
 - ✅ **Automatic cleanup** preventing persistent state
 
-The combination of the MCP fuzzer's built-in safety system and GitHub Actions' security model provides multiple layers of protection, making this e2e test suitable for automated CI/CD pipelines.
+The combination of MCP fuzzer safety controls and GitHub Actions security boundaries provides multiple layers of protection, making this e2e test suitable for automated CI/CD pipelines.

--- a/docs/SECURITY_CI.md
+++ b/docs/SECURITY_CI.md
@@ -70,9 +70,16 @@ jobs:
       env:
         MCP_FUZZER_SAFETY_ENABLED: 'true'   # argument-level safety hooks
         MCP_FUZZER_TIMEOUT: '30'
+        MCP_FUZZER_FS_ROOT: '/tmp/mcp_fuzzer_sandbox'
       run: |
         chmod +x tests/e2e/test_everything_server_docker.sh
-        ./tests/e2e/test_everything_server_docker.sh --enable-safety-system
+        ./tests/e2e/test_everything_server_docker.sh \
+          --enable-safety-system \
+          --fs-root /tmp/mcp_fuzzer_sandbox \
+          --no-network \
+          --allow-host localhost \
+          --allow-host 127.0.0.1 \
+          --allow-host ::1
 
     - name: Upload results
       uses: actions/upload-artifact@v4

--- a/docs/SECURITY_CI.md
+++ b/docs/SECURITY_CI.md
@@ -9,10 +9,10 @@ The e2e test script can be safely run in GitHub Actions with the following secur
 ## 🔒 Security Safeguards
 
 ### 1. **Safety System Integration**
-- **Command Blocking**: Prevents execution of dangerous system commands
-- **Filesystem Sandboxing**: All file operations confined to designated directories
-- **Process Isolation**: Each test runs in isolated process environment
-- **Network Restrictions**: No external network access allowed
+- **Command Blocking**: Prevents execution of dangerous system commands when `--enable-safety-system` is set
+- **Filesystem Sandboxing**: Constrains file paths when `--fs-root` (or `MCP_FUZZER_FS_ROOT`) is set
+- **Process Management**: Stdio servers run as managed subprocesses with watchdog timeouts
+- **Network Restrictions**: Available via `--no-network` + `--allow-host` (not enabled by default)
 
 ### 2. **CI Environment Protections**
 - **Ephemeral Runners**: GitHub Actions runners are destroyed after each run
@@ -30,14 +30,12 @@ google-chrome, safari, edge, opera, brave
 ```
 
 #### Filesystem Controls
-- All file operations use sandboxed directories
-- No access to system-critical files
-- Temporary files automatically cleaned up
+- File arguments are sanitized when a sandbox root is set (`--fs-root` or `MCP_FUZZER_FS_ROOT`)
+- System directories are rejected or rewritten into the sandbox
 
 #### Process Management
-- Process watchdog monitors all subprocesses
+- Process watchdog monitors subprocesses
 - Automatic termination of hanging processes
-- Resource usage tracking and limits
 
 ## 🚀 CI/CD Implementation
 
@@ -70,7 +68,7 @@ jobs:
 
     - name: Run e2e test
       env:
-        MCP_FUZZER_SAFETY_ENABLED: 'true'
+        MCP_FUZZER_SAFETY_ENABLED: 'true'   # argument-level safety hooks
         MCP_FUZZER_TIMEOUT: '30'
       run: |
         chmod +x tests/e2e/test_everything_server_docker.sh
@@ -89,15 +87,15 @@ jobs:
 
 1. **File System Access**
    - **Risk**: Could potentially access sensitive files
-   - **Mitigation**: Sandboxed to `/tmp` and project directories only
+   - **Mitigation**: Use `--fs-root` (or `MCP_FUZZER_FS_ROOT`) to enforce a sandbox
 
 2. **Process Execution**
    - **Risk**: Could spawn malicious processes
-   - **Mitigation**: Command blocking prevents dangerous executables
+   - **Mitigation**: Use `--enable-safety-system` to install command blockers
 
 3. **Resource Consumption**
    - **Risk**: Could exhaust CI resources
-   - **Mitigation**: GitHub Actions timeouts and resource limits
+   - **Mitigation**: GitHub Actions timeouts + watchdog timeouts
 
 4. **Data Exposure**
    - **Risk**: Test results could contain sensitive information
@@ -111,6 +109,7 @@ jobs:
 MCP_FUZZER_SAFETY_ENABLED=true
 MCP_FUZZER_TIMEOUT=30
 MCP_FUZZER_FS_ROOT=/tmp/mcp_fuzzer_sandbox
+MCP_FUZZER_ICON_THEME=ascii
 ```
 
 ### Resource Limits
@@ -126,15 +125,15 @@ MCP_FUZZER_FS_ROOT=/tmp/mcp_fuzzer_sandbox
 ## ✅ Safety Verification
 
 ### Pre-Flight Checks
-- [x] Safety system enabled by default
-- [x] Command blocking active
-- [x] Filesystem sandboxing configured
-- [x] Process isolation working
-- [x] Network restrictions applied
+- [x] Argument-level safety enabled (default unless `--no-safety`)
+- [x] Command blocking enabled (`--enable-safety-system`)
+- [x] Filesystem sandboxing configured (`--fs-root` or `MCP_FUZZER_FS_ROOT`)
+- [x] Process watchdog active
+- [x] Network restrictions configured (`--no-network` + `--allow-host`) when needed
 
 ### Runtime Monitoring
 - [x] Process watchdog active
-- [x] Resource usage tracking
+- [x] Watchdog monitoring
 - [x] Automatic cleanup on failure
 - [x] Comprehensive logging
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -21,35 +21,34 @@ flowchart TB
     A1[Parser (cli/parser.py)]
     A2[Config Merge (cli/config_merge.py)]
     A3[Validation Manager (cli/validators.py)]
-    A4[Entrypoint runner (cli/entrypoint.py)]
+    A4[Entrypoint (cli/entrypoint.py)]
   end
 
   subgraph Client
-    B1[MCPFuzzerClient (client/main.py)]
-    B2[Safety Integration]
-    B3[Reporting Integration]
+    B0[Unified Runner (client/main.py)]
+    B1[MCPFuzzerClient (client/base.py)]
+    B2[ToolClient]
+    B3[ProtocolClient]
   end
 
   subgraph Transports
+    C0[Transport Drivers]
     C1[HTTP]
     C2[SSE]
     C3[STDIO]
-    C4[Custom Drivers]
+    C4[StreamableHTTP]
+    C5[Custom Drivers]
   end
 
-  subgraph Fuzz_Engine
-    D1[ToolExecutor]
-    D2[ProtocolExecutor]
-    D3[Mutators]
-    D4[AsyncFuzzExecutor]
-    D5[FuzzerReporter]
+  subgraph Mutators
+    D1[ToolMutator]
+    D2[ProtocolMutator]
+    D3[Seed Pool / Corpus]
   end
 
   subgraph Runtime[Async Runtime]
     R1[ProcessManager]
     R2[ProcessWatchdog]
-    R3[Process Lifecycle]
-    R4[Signal Handling]
   end
 
   subgraph Safety_System
@@ -60,35 +59,39 @@ flowchart TB
 
   subgraph Reports
     F1[FuzzerReporter]
-    F2[Formatters]
-    F3[SafetyReporter]
+    F2[OutputManager]
+    F3[Formatters]
+    F4[SafetyReporter]
   end
 
-  A1 --> A2 --> A3 --> A4
-  A4 --> B1
+  A1 --> A2 --> A3 --> A4 --> B0 --> B1
+  B1 --> B2
+  B1 --> B3
 
-  B1 --> C1
-  B1 --> C2
-  B1 --> C3
-  B1 --> C4
-  B1 --> D1
-  B1 --> D2
+  C0 --> C1
+  C0 --> C2
+  C0 --> C3
+  C0 --> C4
+  C0 --> C5
+
+  B2 --> C0
+  B3 --> C0
+  B2 --> D1
+  B3 --> D2
+  D1 --> D3
+  D2 --> D3
+
+  B2 --> E1
+  B3 --> E1
+  E1 --> F4
+
   B1 --> F1
-
-  D1 --> E1
-  D2 --> E1
-  D1 --> D4
-  D2 --> D4
+  F1 --> F2
+  F1 --> F3
+  C0 -.-> E3
 
   C3 -.-> R1
   R1 --> R2
-  R2 -.-> R3
-  R1 -.-> R4
-
-  B1 --> E1
-  E1 --> F3
-  F1 --> F2
-  C1 -.-> E3
 ```
 
 ## Data Flow
@@ -99,31 +102,31 @@ flowchart TB
 graph TD
     A[CLI] --> B[Parse Arguments]
     B --> C[Merge CLI + Config]
-    C --> D[Validate Args/Env/Transport]
-    D --> E[Create Transport (build_driver)]
+    C --> D[Validate Args/Env]
+    D --> E[Build Transport + Auth]
     E --> F[Init Client + Reporter]
-    F --> G[Discover Tools]
+    F --> G[Build Run Plan]
     G --> H{Mode}
 
-    H -->|Tools| I[ToolExecutor]
-    H -->|Protocol| J[Spec Guard] --> K[ProtocolExecutor]
+    H -->|Tools| I[ToolClient]
+    H -->|Protocol| J[Spec Guard] --> K[ProtocolClient]
+    H -->|Resources/Prompts| J --> K
+    H -->|All| I --> J --> K
 
     I --> L[ToolMutator]
-    K --> M[ProtocolMutator]
+    L --> M[SafetyFilter (tool args)]
+    M --> N[Send tool call via Transport]
 
-    L --> N[AsyncFuzzExecutor]
-    M --> N
-    N --> O[Send via Transport]
+    K --> P[ProtocolMutator]
+    P --> Q[SafetyFilter (protocol)]
+    Q --> R[Send raw via Transport]
+    K -.-> S[Stateful Sequences (optional)]
+    S --> R
 
-    O --> P{SafetyFilter}
-    P -->|Block| Q[Log + Mock Response]
-    P -->|Allow/Sanitize| R[Execute Request]
-
-    R --> S[Collect Results]
-    Q --> S
-
-    S --> T[Reporter Formats + Writes]
-    T --> U[Console/Files]
+    N --> T[Collect Results]
+    R --> T
+    T --> U[Reporter + OutputManager]
+    U --> V[Console/Files]
 ```
 
 ### Safety System Flow
@@ -363,13 +366,12 @@ The safety system provides multiple layers of protection against dangerous opera
 **Safety Features:**
 
 - **Pluggable Safety Providers**: Protocol-based safety system allowing custom implementations
-- **Pattern-Based Filtering**: Comprehensive pattern matching for dangerous content
-- **SafetyFilter Class**: Main implementation with URL/command blocking
+- **Pattern Detection Helpers**: `DangerDetector` is available for custom providers
+- **SafetyFilter Class**: Default provider with optional filesystem path sanitization
 - **System Command Blocking**: The `SystemCommandBlocker` PATH shim prevents execution of dangerous commands
-- **Filesystem Sandboxing**: Confines file operations to specified directories
-- **Process Isolation**: Safe subprocess handling with timeouts
-- **Input Sanitization**: Filters potentially dangerous input
-- **Mock Response Generation**: Safe responses for blocked operations
+- **Filesystem Sandboxing**: Confines file operations to specified directories when enabled
+- **Process Management**: Safe subprocess handling with timeouts
+- **Optional Mock Responses**: Helpers to build safe JSON-RPC errors if you choose to block
 
 ### 9. Authentication System
 
@@ -465,7 +467,7 @@ The configuration system provides centralized configuration management with mult
 
 ### 11. Reporting System
 
-The reporting system provides centralized output management and comprehensive result reporting with multiple output formats and real-time progress tracking.
+The reporting system provides centralized output management and comprehensive result reporting with multiple output formats and standardized artifacts.
 
 **Key Components:**
 
@@ -478,14 +480,14 @@ The reporting system provides centralized output management and comprehensive re
 
 - **Multi-Format Output**: Console summaries plus JSON, text, CSV, XML, HTML, and Markdown exports
 - **Standardized Artifacts**: Output protocol produces structured JSON bundles for fuzzing, safety, and error data
-- **Real-time Progress**: Live progress indicators and status updates during fuzzing
-- **Result Aggregation**: Comprehensive statistics, success rates, and performance metrics
+- **Console Summaries**: Rich startup configuration tables and end-of-run summaries
+- **Result Aggregation**: Comprehensive statistics, success rates, and execution timing
 - **Safety Reporting**: Detailed breakdown of blocked operations, risk assessments, and security events
-- **Session Tracking**: Timestamped reports with unique session identification and metadata
+- **Session Tracking**: Session-id based reports with timestamps captured in metadata
 
 **Output Formats:**
 
-- **Console**: Interactive tables with colors, progress bars, and real-time updates
+- **Console**: Rich tables with colors and summary output
 - **JSON/Text**: Machine-readable structured data plus readable summaries for doc handoffs
 - **CSV/XML**: Spreadsheet- and enterprise-friendly formats for data analysis
 - **HTML/Markdown**: Presentation-ready exports for reports and runbooks
@@ -495,29 +497,27 @@ The reporting system provides centralized output management and comprehensive re
 
 - **Fuzzing Reports**: Complete tool and protocol testing results with detailed metrics
 - **Safety Reports**: Comprehensive safety system data, blocked operations, and risk analysis
-- **Session Reports**: Execution metadata, configuration snapshots, and performance statistics
-- **Performance Reports**: Detailed timing, resource usage, and scalability metrics
+- **Session Reports**: Execution metadata and timing statistics
+- **Performance Reports**: Reserved for future timing/resource metrics
 - **Error Reports**: Categorized error analysis with root cause identification
 
 **Reporting Architecture:**
 
 ```mermaid
 graph TD
-    A[Fuzzing Engine] --> B[FuzzerReporter]
-    B --> C{Output Format}
-    C -->|Console| D[ConsoleFormatter]
-    C -->|JSON| E[JSONFormatter]
-    C -->|Text| F[TextFormatter]
-    C -->|CSV| G[CSVFormatter]
+    A[Fuzzing Clients] --> B[FuzzerReporter]
+    B --> C[OutputManager]
+    C --> D[Standardized JSON Sessions]
+
+    B --> E[FormatterRegistry]
+    E --> F[ConsoleFormatter]
+    E --> G[JSON/Text/CSV/XML/HTML/Markdown]
 
     B --> H[SafetyReporter]
-    H --> I[Risk Assessment]
-    H --> J[Blocked Operations]
 
-    D --> K[Terminal Output]
-    E --> L[File System]
-    F --> L
-    G --> L
+    F --> I[Terminal Output]
+    G --> J[Report Files]
+    H --> J
 ```
 
 **Configuration Options:**
@@ -531,7 +531,7 @@ output:
     - "fuzzing_results"
     - "error_report"
     - "safety_summary"
-    - "performance_metrics"
+  # performance_metrics and configuration_dump are reserved
   schema: "./custom_schema.json" # Custom output schema file
 ```
 
@@ -633,39 +633,42 @@ The `AsyncFuzzExecutor` provides controlled concurrency and robust error handlin
 ```mermaid
 sequenceDiagram
     participant CLI as CLI
-    participant Client as Unified Client
+    participant Runner as Unified Runner
+    participant ToolClient as ToolClient
+    participant Mutator as ToolMutator
+    participant Safety as SafetyFilter
+    participant Auth as AuthManager
     participant Transport as Transport
     participant Server as MCP Server
-    participant Fuzzer as Tool Fuzzer
-    participant Executor as AsyncFuzzExecutor
-    participant Strategy as Strategy Manager
+    participant Reporter as Reporter
 
-    CLI->>Client: Initialize with transport
-    Client->>Transport: Create transport instance
-    Transport->>Server: Discover available tools
-    Server-->>Transport: Return tool list
-    Transport-->>Client: Tool list received
+    CLI->>Runner: Start run
+    Runner->>ToolClient: Fuzz tools
+    ToolClient->>Transport: tools/list
+    Transport->>Server: tools/list
+    Server-->>Transport: tools
+    Transport-->>ToolClient: tool list
 
-    loop For each tool
-        Client->>Fuzzer: Fuzz tool
-        Fuzzer->>Strategy: Request test data
-        Strategy-->>Fuzzer: Return test data
-
-        Fuzzer->>Executor: Execute batch operations
-
-        loop For each test run (concurrent)
-            Executor->>Client: Execute tool call
-            Client->>Transport: Send tool request
-            Transport->>Server: Execute tool
-            Server-->>Transport: Return result
-            Transport-->>Client: Result received
-            Client-->>Executor: Tool result
-            Executor->>Fuzzer: Record result
+    loop For each tool/run
+        ToolClient->>Mutator: mutate(tool)
+        Mutator-->>ToolClient: args
+        ToolClient->>Safety: sanitize (fs-root) / optional block
+        alt Custom block
+            Safety-->>ToolClient: blocked
+            ToolClient->>Reporter: record blocked
+        else Pass-through
+            Safety-->>ToolClient: args (pass-through / fs-root sanitized)
+            ToolClient->>Auth: get auth params
+            Auth-->>ToolClient: auth params
+            ToolClient->>Transport: tools/call
+            Transport->>Server: call tool
+            Server-->>Transport: result/error
+            Transport-->>ToolClient: response
+            ToolClient->>Reporter: record result + spec checks
         end
     end
 
-    Fuzzer-->>Client: Fuzzing complete
-    Client-->>CLI: Generate report
+    Runner-->>Reporter: write reports
 ```
 
 ### Protocol Fuzzing Flow
@@ -673,36 +676,43 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant CLI as CLI
-    participant Client as Unified Client
+    participant Runner as Unified Runner
+    participant SpecGuard as Spec Guard
+    participant ProtocolClient as ProtocolClient
+    participant Mutator as ProtocolMutator
+    participant Safety as SafetyFilter
     participant Transport as Transport
     participant Server as MCP Server
-    participant Fuzzer as Protocol Fuzzer
-    participant Executor as AsyncFuzzExecutor
-    participant Strategy as Strategy Manager
+    participant Reporter as Reporter
 
-    CLI->>Client: Initialize with transport
-    Client->>Transport: Create transport instance
+    CLI->>Runner: Start run
+    Runner->>SpecGuard: run spec suite (protocol/resources/prompts)
+    SpecGuard-->>Reporter: record checks
+    Runner->>ProtocolClient: Fuzz protocol types
 
-    loop For each protocol type
-        Client->>Fuzzer: Fuzz protocol type
-        Fuzzer->>Strategy: Request protocol messages
-        Strategy-->>Fuzzer: Return test messages
-
-        Fuzzer->>Executor: Execute batch operations
-
-        loop For each test run (concurrent)
-            Executor->>Client: Execute protocol message
-            Client->>Transport: Send protocol message
-            Transport->>Server: Execute protocol
-            Server-->>Transport: Return response
-            Transport-->>Client: Response received
-            Client-->>Executor: Protocol response
-            Executor->>Fuzzer: Record result
+    loop For each protocol type/run
+        ProtocolClient->>Mutator: mutate(protocol_type, protocol_phase)
+        Mutator-->>ProtocolClient: message
+        ProtocolClient->>Safety: optional block/sanitize (custom)
+        alt Custom block
+            Safety-->>ProtocolClient: blocked
+            ProtocolClient->>Reporter: record blocked
+        else Pass-through
+            Safety-->>ProtocolClient: message (pass-through)
+            ProtocolClient->>Transport: send_raw
+            Transport->>Server: request
+            Server-->>Transport: response
+            Transport-->>ProtocolClient: response
+            ProtocolClient->>Reporter: record result + spec checks
         end
     end
 
-    Fuzzer-->>Client: Fuzzing complete
-    Client-->>CLI: Generate report
+    opt Stateful enabled
+        ProtocolClient->>Mutator: build stateful sequence
+        ProtocolClient->>Transport: send sequence
+    end
+
+    Runner-->>Reporter: write reports
 ```
 
 ## Design Principles
@@ -737,10 +747,10 @@ The system is designed for extensibility:
 
 Safety is built into every layer:
 
-- **Danger pattern detection** blocks suspicious URLs, scripts, and command content
-- **Input sanitization** filters potentially dangerous data
-- **System command blocking** prevents command execution
-- **Filesystem sandboxing** confines file operations
+- **Danger pattern helpers** are available for custom safety providers
+- **Filesystem path sanitization** when the sandbox is enabled
+- **System command blocking** prevents command execution when enabled
+- **Network policy controls** restrict outbound hosts when configured
 
 ### 5. Testability
 
@@ -801,7 +811,7 @@ The architecture supports scaling:
 
 - **Configurable async concurrency limits** through AsyncFuzzExecutor semaphores
 - **Batch execution** for tool runs and protocol messages
-- **Watchdog performance metrics** to inform resource planning
+- **Watchdog stats** (process counts, last scan time) to inform resource planning
 - **Standardized output artifacts** for CI/CD and fleet orchestration
 
 ## Security Considerations
@@ -812,38 +822,36 @@ All input is validated and sanitized:
 
 - **Argument validation** at CLI level
 - **Transport-level JSON-RPC validation and serialization checks**
-- **Safety system filtering** via the `DangerDetector`
-- **Filesystem path sanitization** through the sandbox
+- **Safety system hooks** for optional filesystem path sanitization and command blocking
+- **Filesystem path sanitization** when the sandbox is enabled
 - **Host normalization** for network access control
 
 ### Access Control
 
 The system implements access control:
 
-- **Filesystem sandboxing**
-- **Process isolation**
-- **System command blocking**
-- **Network policy enforcement** for redirects and outbound requests
+- **Filesystem sandboxing** (opt-in via `--fs-root`)
+- **System command blocking** (opt-in via `--enable-safety-system`)
+- **Network policy enforcement** for redirects and outbound requests (`--no-network`, `--allow-host`)
 
 ### Audit Logging
 
-Comprehensive logging for security:
+Security-relevant events are logged:
 
-- **All operations are logged**
 - **Safety system actions are recorded**
 - **Error conditions are tracked**
-- **Performance metrics are collected**
+- **Transport failures and retries are logged**
 
 ## Monitoring and Observability
 
 ### Metrics Collection
 
-The system collects various metrics:
+The system does not emit a continuous metrics stream by default. Available
+signals include:
 
-- **Request success/failure rates**
-- **Response times**
-- **Error counts and types**
-- **Resource usage**
+- **Success/error counts** in reports
+- **Execution time** in report metadata
+- **Watchdog stats** for managed subprocesses
 
 ### Logging
 
@@ -851,7 +859,6 @@ Comprehensive logging throughout:
 
 - **Structured logging** with levels
 - **Context-aware log messages**
-- **Performance timing information**
 - **Error stack traces**
 
 ### Health Checks
@@ -872,7 +879,7 @@ The MCP Fuzzer is designed as a modular system with clear integration points:
 - **Transport Abstraction**: All communication is abstracted through the TransportDriver interface, allowing any transport to work with the system.
 - **Safety Providers**: The safety system uses a provider interface allowing customization of safety features.
 - **Strategy Extensions**: Fuzzing strategies can be extended with new generators for different data types.
-- **Runtime Management**: The async runtime provides process isolation and management for all components.
+- **Runtime Management**: The async runtime provides subprocess management and watchdog supervision.
 - **Execution Framework**: The AsyncFuzzExecutor provides a bridge between strategies and execution.
 
 ### External Integration

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -483,7 +483,7 @@ The reporting system provides centralized output management and comprehensive re
 - **Console Summaries**: Rich startup configuration tables and end-of-run summaries
 - **Result Aggregation**: Comprehensive statistics, success rates, and execution timing
 - **Safety Reporting**: Detailed breakdown of blocked operations, risk assessments, and security events
-- **Session Tracking**: Session-id based reports with timestamps captured in metadata
+- **Session Tracking**: Session-ID-based reports with timestamps captured in metadata
 
 **Output Formats:**
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -368,7 +368,7 @@ The safety system provides multiple layers of protection against dangerous opera
 - **Pluggable Safety Providers**: Protocol-based safety system allowing custom implementations
 - **Pattern Detection Helpers**: `DangerDetector` is available for custom providers
 - **SafetyFilter Class**: Default provider with optional filesystem path sanitization
-- **System Command Blocking**: The `SystemCommandBlocker` PATH shim prevents execution of dangerous commands
+- **System Command Blocking**: When system-level safety is enabled, the `SystemCommandBlocker` PATH shim can be installed to prevent dangerous commands
 - **Filesystem Sandboxing**: Confines file operations to specified directories when enabled
 - **Process Management**: Safe subprocess handling with timeouts
 - **Optional Mock Responses**: Helpers to build safe JSON-RPC errors if you choose to block

--- a/docs/architecture/client-architecture.md
+++ b/docs/architecture/client-architecture.md
@@ -9,11 +9,17 @@ The client package is organized into several modules, each with a specific respo
 ```
 mcp_fuzzer/
 ├── client/
-│   ├── __init__.py              # Exports main client class
-│   ├── base.py                  # Base client class with common functionality
+│   ├── __init__.py              # Exports client APIs
+│   ├── base.py                  # MCPFuzzerClient orchestration
+│   ├── main.py                  # Unified runner used by the CLI
+│   ├── settings.py              # ClientSettings / config access
 │   ├── tool_client.py           # Tool fuzzing functionality
 │   ├── protocol_client.py       # Protocol fuzzing functionality
-│   └── utils.py                 # Utility functions
+│   ├── runtime/                 # Run plan + execution pipeline
+│   ├── transport/               # Transport factory + auth integration
+│   ├── adapters/                # Config adapter (port/adapter)
+│   ├── ports/                   # Port interfaces
+│   └── safety/                  # Safety system wiring
 ```
 
 ## Components
@@ -46,14 +52,26 @@ The `ProtocolClient` class in `protocol_client.py` handles all protocol-related 
 - Safety checks for protocol messages
 - Sending different types of protocol requests
 
-### Utilities (`utils.py`)
+### Unified Runner (`main.py`)
 
-The `utils.py` module provides common utility functions used across the client package:
+The unified runner wires CLI settings into the client and run plan:
 
-- Getting tool names with fallbacks
-- Creating standardized error results
-- Calculating success rates
-- Running operations with timeouts
+- Builds the transport with auth via `build_driver_with_auth`
+- Initializes `MCPFuzzerClient` and `FuzzerReporter`
+- Executes the run plan (tools, spec guard, protocol, stateful)
+
+### Runtime Pipeline (`client/runtime/`)
+
+The runtime package includes:
+
+- `run_plan.py` - Ordered run steps per mode
+- `pipeline.py` - Execution pipeline (tools/protocol/resources/prompts/stateful)
+- `argv_builder.py` and `async_runner.py` - Inner-argv handling and execution
+
+### Settings and Adapters
+
+- `settings.py` encapsulates merged config into `ClientSettings`.
+- `adapters/` + `ports/` provide a Port & Adapter boundary around config access.
 
 ## Benefits of the New Architecture
 

--- a/docs/architecture/fuzz-engine.md
+++ b/docs/architecture/fuzz-engine.md
@@ -12,6 +12,10 @@ The fuzz engine has been refactored into three distinct, specialized modules tha
 
 This modular design enables better testability, maintainability, and extensibility while maintaining high performance through asynchronous execution.
 
+Note: The CLI runtime primarily uses the `client` package (`ToolClient` /
+`ProtocolClient`) and the newer reporting pipeline. The `fuzz_engine` package
+remains available as a lower-level API for direct integration or legacy use.
+
 ## Architecture Diagram
 
 ```mermaid
@@ -56,7 +60,7 @@ graph TD
     subgraph External[External Systems]
         SS[SafetySystem]
         TR[Transport]
-        CL[Client]
+        CL[Direct Engine API]
     end
 
     TE --> TM
@@ -434,7 +438,7 @@ class MetricsCalculator:
 
 ```mermaid
 sequenceDiagram
-    participant Client
+    participant EngineUser
     participant ToolExecutor
     participant ToolMutator
     participant AsyncExecutor
@@ -442,7 +446,7 @@ sequenceDiagram
     participant ResultBuilder
     participant ResultCollector
 
-    Client->>ToolExecutor: execute(tool, runs=10)
+    EngineUser->>ToolExecutor: execute(tool, runs=10)
     ToolExecutor->>AsyncExecutor: execute_batch(operations)
 
     loop For each run (concurrent)
@@ -463,14 +467,17 @@ sequenceDiagram
     AsyncExecutor-->>ToolExecutor: batch_results
     ToolExecutor->>ResultCollector: collect_results(batch_results)
     ResultCollector-->>ToolExecutor: aggregated_results
-    ToolExecutor-->>Client: results
+    ToolExecutor-->>EngineUser: results
 ```
+
+Note: the default `SafetyFilter` does not block tool calls; the "Blocked" branch
+applies when custom safety providers enforce blocking.
 
 ### Protocol Fuzzing Flow
 
 ```mermaid
 sequenceDiagram
-    participant Client
+    participant EngineUser
     participant ProtocolExecutor
     participant ProtocolMutator
     participant AsyncExecutor
@@ -478,7 +485,7 @@ sequenceDiagram
     participant Invariants
     participant ResultBuilder
 
-    Client->>ProtocolExecutor: execute(protocol_type, runs=10)
+    EngineUser->>ProtocolExecutor: execute(protocol_type, runs=10)
     ProtocolExecutor->>AsyncExecutor: execute_batch(operations)
 
     loop For each run (concurrent)
@@ -502,42 +509,34 @@ sequenceDiagram
     end
 
     AsyncExecutor-->>ProtocolExecutor: batch_results
-    ProtocolExecutor-->>Client: results
+    ProtocolExecutor-->>EngineUser: results
 ```
 
 ## Integration Points
 
-### Client Integration
+### Client Integration (Current)
 
-The fuzz engine integrates with clients through executor classes:
+The CLI uses `MCPFuzzerClient`, which delegates to `ToolClient` and
+`ProtocolClient` built on mutators and the `JsonRpcAdapter`:
 
 ```python
-# Tool Client
-class ToolClient:
-    def __init__(self, transport, safety_system):
-        mutator = ToolMutator()
-        self.executor = ToolExecutor(
-            mutator=mutator,
-            safety_system=safety_system,
-            max_concurrency=5
-        )
+from mcp_fuzzer.client import MCPFuzzerClient
+from mcp_fuzzer.transport.catalog import build_driver
 
-    async def fuzz_tool(self, tool, runs=10):
-        return await self.executor.execute(tool, runs)
+transport = build_driver("http", "http://localhost:8000")
+client = MCPFuzzerClient(transport)
 
-# Protocol Client
-class ProtocolClient:
-    def __init__(self, transport):
-        self.mutator = ProtocolMutator()
-        self.executor = ProtocolExecutor(
-            mutator=self.mutator,
-            transport=transport,
-            max_concurrency=5
-        )
-
-    async def fuzz_protocol_type(self, protocol_type, runs=10):
-        return await self.executor.execute(protocol_type, runs)
+tool_results = await client.fuzz_all_tools(runs_per_tool=5)
+protocol_results = await client.fuzz_all_protocol_types(
+    runs_per_type=3,
+    phase="realistic",
+)
 ```
+
+### Direct Engine Integration (Optional)
+
+`ToolExecutor`/`ProtocolExecutor` remain available for direct embedding when you
+want to drive the `fuzz_engine` module independently of the CLI.
 
 ### Safety System Integration
 

--- a/docs/architecture/fuzzer-design.md
+++ b/docs/architecture/fuzzer-design.md
@@ -31,7 +31,7 @@ graph TD
     Mutator --> SeedPool[Seed Pool]
     Strategy --> Payloads[Payload + Boundary Gen]
     Mutator --> Request[Build Request]
-    Request --> Transport[Transport (HTTP/SSE/stdio)]
+    Request --> Transport[Transport (HTTP/SSE/STDIO/StreamableHTTP)]
     Transport --> Target[MCP Server]
     Target --> Response[Response]
     Response --> Checks[Spec + Safety Checks]

--- a/docs/components/process-management-guide.md
+++ b/docs/components/process-management-guide.md
@@ -469,6 +469,7 @@ debug_executor = AsyncFuzzExecutor(
 async def monitor_processes(manager):
     while True:
         stats = await manager.get_stats()
+        # stats includes status counts + watchdog stats
         print(f"Process stats: {stats}")
 
         # List all processes
@@ -489,17 +490,31 @@ async def monitor_watchdog(watchdog):
         await asyncio.sleep(5)
 ```
 
-#### Executor Statistics
+#### Executor Observability
+
+`AsyncFuzzExecutor` does not expose built-in counters. Track concurrency in the
+caller if you need it:
 
 ```python
-async def monitor_executor(executor):
-    # Monitor running tasks
-    running_count = len(executor._running_tasks)
-    print(f"Running tasks: {running_count}")
+stats = {"in_flight": 0, "completed": 0}
 
-    # Monitor semaphore
-    semaphore_count = executor._semaphore._value
-    print(f"Available semaphore slots: {semaphore_count}")
+def wrap(op, *args, **kwargs):
+    async def _wrapped():
+        stats["in_flight"] += 1
+        try:
+            if asyncio.iscoroutinefunction(op):
+                return await op(*args, **kwargs)
+            return await asyncio.to_thread(op, *args, **kwargs)
+        finally:
+            stats["in_flight"] -= 1
+            stats["completed"] += 1
+
+    return _wrapped
+
+# Wrap operations before passing to execute_batch
+operations = [(wrap(my_async_op), [], {}), (wrap(my_sync_op), [], {})]
+results = await executor.execute_batch(operations)
+print(f"In flight: {stats['in_flight']} Completed: {stats['completed']}")
 ```
 
 ### Error Recovery Patterns

--- a/docs/components/process-management.md
+++ b/docs/components/process-management.md
@@ -24,7 +24,8 @@ AsyncFuzzExecutor (Controlled concurrency)
 
 ### AsyncFuzzExecutor
 
-Provides controlled concurrency for executing asynchronous operations with timeout handling and retry mechanisms.
+Provides controlled concurrency for executing asynchronous operations with
+batch result aggregation.
 
 #### Configuring Concurrency
 
@@ -252,7 +253,7 @@ Note: To deliver CTRL_BREAK_EVENT on Windows, the child must be started in its o
 
 - **Resource Cleanup**: Automatic cleanup on shutdown
 - **Error Handling**: Comprehensive error handling and logging
-- **Process Isolation**: Processes are properly isolated using process groups and async-aware process management
+- **Process Group Management**: Processes are grouped for signal handling and cleanup
 - **Memory Management**: Efficient memory usage with proper cleanup
 
 ## Usage Examples

--- a/docs/components/safety.md
+++ b/docs/components/safety.md
@@ -9,8 +9,8 @@ or programmatically.
 
 The safety subsystem lives under `mcp_fuzzer/safety_system` and is composed of:
 
-- **SafetyFilter** (`safety.py`) – argument-level sanitization backed by the
-  `DangerDetector`, filesystem sandboxing, and mock responses for blocked calls.
+- **SafetyFilter** (`safety.py`) – argument-level hooks plus optional filesystem
+  path sanitization; includes `DangerDetector` helpers for custom blocking.
 - **Filesystem Sandbox** (`filesystem/`) – `FilesystemSandbox` and
   `PathSanitizer` confine file paths to a safe root via `--fs-root` or
   `MCP_FUZZER_FS_ROOT`.
@@ -22,44 +22,39 @@ The safety subsystem lives under `mcp_fuzzer/safety_system` and is composed of:
 - **Safety Reporter** (`reporting/`) – aggregates blocked operations and prints
   detailed reports with `--safety-report` or `--export-safety-data`.
 
-The CLI enables argument-level filtering by default. System command blocking,
+The CLI enables argument-level safety hooks by default. System command blocking,
 filesystem sandboxing, and reporting are opt-in controls layered on top.
 
-## Argument-Level Filtering (`SafetyFilter`)
+## Argument-Level Hooks (`SafetyFilter`)
 
-`SafetyFilter` detects and sanitizes dangerous arguments before they reach the
-target server. It is built around the `DangerDetector`, which groups patterns
-into three categories:
+`SafetyFilter` is the default safety provider for tool fuzzing. It intentionally
+passes URL/script/command payloads through so the server is tested with real
+inputs. Protection happens at system boundaries instead:
 
-- **Dangerous URLs** – `http(s)://`, `ftp://`, `file://`, and TLD-based matches.
-- **Script Injection** – `<script>` tags, `javascript:` URIs, DOM APIs, and event
-  handler attributes.
-- **Command Patterns** – Browser launches (`open`, `start`, `xdg-open`),
-  shell/exec references, `sudo`, `rm -rf`, and other risky command strings.
+- **System command blocking** (`--enable-safety-system`)
+- **Filesystem sandboxing** (`--fs-root`)
+- **Network policy controls** (`--no-network`, `--allow-host`)
 
-When a match is found, SafetyFilter records the operation, rewrites the argument
-into a safe placeholder, and can fabricate a mock JSON-RPC error so the fuzzer
-continues without running arbitrary code.
+When a sandbox root is set, filesystem paths are rewritten into safe equivalents
+under that root. `DangerDetector` helpers are still available if you want to
+implement stricter blocking in a custom safety provider.
 
 ```python
 from mcp_fuzzer.safety_system.safety import SafetyFilter
 
 filter = SafetyFilter()
+filter.set_fs_root("/tmp/mcp_sandbox")
 
-args = {
-    "url": "https://evil.example/payload",
-    "output_path": "/etc/passwd",
-}
-
-sanitized = filter.sanitize_tool_arguments("web_tool", args)
-should_skip = filter.should_skip_tool_call("web_tool", args)
-
-if should_skip:
-    safe_response = filter.create_safe_mock_response("web_tool")
+args = {"output_path": "/etc/passwd"}
+sanitized = filter.sanitize_tool_arguments("file_tool", args)
+# sanitized["output_path"] now points inside /tmp/mcp_sandbox
 ```
 
 Filesystem arguments are sanitized automatically once a sandbox root is set
 (either through the CLI or by calling `set_fs_root()` on the filter).
+
+If you implement stricter blocking in a custom provider, you can use
+`create_safe_mock_response()` to fabricate a consistent JSON-RPC error.
 
 ## Filesystem Sandbox
 
@@ -67,8 +62,12 @@ The sandbox forces all file paths to stay under a safe directory. It is powered
 by `FilesystemSandbox` and the `PathSanitizer` heuristics discussed earlier.
 
 - CLI flag: `--fs-root /tmp/mcp_fuzzer_safe`
-- Environment variable: `MCP_FUZZER_FS_ROOT=~/.mcp_fuzzer`
+- Environment variable: `MCP_FUZZER_FS_ROOT=/tmp/mcp_fuzzer_safe`
 - Programmatic: `SafetyFilter().set_fs_root("/tmp/mcp")`
+
+If you do not set `--fs-root` (or `MCP_FUZZER_FS_ROOT` in environments where it
+is applied), the filesystem sandbox is not initialized and file paths are not
+confined.
 
 The sandbox rejects system directories (`/`, `/etc`, `/usr`, etc.), enforces
 0700 permissions, and rewrites suspicious arguments (e.g., `../../etc/passwd`)
@@ -116,8 +115,8 @@ blocking if you cancel an unsafe run.
 | Flag | Description |
 | --- | --- |
 | `--enable-safety-system` | Activate PATH shims for browsers/launchers. |
-| `--fs-root PATH` | Set the filesystem sandbox root (defaults to `~/.mcp_fuzzer`). |
-| `--no-safety` | Disable argument-level filtering (not recommended). |
+| `--fs-root PATH` | Set the filesystem sandbox root (only applied when provided). |
+| `--no-safety` | Disable argument-level safety hooks (not recommended). |
 | `--safety-report` | Print the full safety report at the end of the session. |
 | `--export-safety-data [FILE]` | Save safety data as JSON, optionally to a custom filename. |
 | `--retry-with-safety-on-interrupt` | Re-run once with system blocking after Ctrl-C. |
@@ -151,8 +150,8 @@ When both CLI flags and environment variables are provided, CLI values win.
 
 When `--safety-report` is enabled, the `SafetyReporter` prints:
 
-- Whether SafetyFilter was active and how many tool calls were sanitized.
-- A table of blocked operations (tool name, reason, sanitized argument).
+- SafetyFilter statistics (blocked operations count, risk assessment) if any.
+- A table of blocked operations when custom SafetyFilter logic is used.
 - System command blocker statistics (count and preview of attempts).
 
 `--export-safety-data` writes the same structured data to disk so you can attach
@@ -175,6 +174,9 @@ custom_filter = SafetyFilter(
     dangerous_argument_names=["path", "command"],
 )
 ```
+
+Note: the default `SafetyFilter` does not block on these patterns; override
+`should_skip_tool_call()` or implement a custom provider to enforce them.
 
 To swap the filesystem sandbox implementation, implement the `SandboxProvider`
 protocol and pass it to `SafetyFilter`:

--- a/docs/configuration/configuration-loader.md
+++ b/docs/configuration/configuration-loader.md
@@ -183,7 +183,7 @@ output:
     - "fuzzing_results"
     - "error_report"
     - "safety_summary"
-    - "performance_metrics"
+  # performance_metrics and configuration_dump are reserved
   retention:
     days: 30                     # Retain files for N days
     max_size: "1GB"              # Maximum directory size

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -28,14 +28,22 @@ Create a `mcp-fuzzer.yaml` or `mcp-fuzzer.yml` file:
 #   - all: Run tools + protocol fuzzing with spec checks
 mode: tools
 phase: aggressive
+# protocol_phase applies to protocol/resources/prompts/stateful fuzzing
+protocol_phase: realistic
 protocol: http
 endpoint: "http://localhost:8000/mcp/"
 runs: 10
 runs_per_type: 5
 # protocol_type: Protocol message schema to fuzz in protocol mode.
-# See ProtocolExecutor.PROTOCOL_TYPES in
-# mcp_fuzzer/fuzz_engine/executor/protocol_executor.py for the canonical list.
+# See EXECUTABLE_PROTOCOL_TYPES in
+# mcp_fuzzer/protocol_registry.py for the canonical list.
 protocol_type: "InitializeRequest"
+
+# Stateful + corpus controls
+stateful: false
+stateful_runs: 5
+corpus_enabled: true
+havoc_mode: false
 
 # Spec guard configuration
 # spec_guard: Enable deterministic MCP spec checks for protocol/resources/prompts
@@ -46,6 +54,8 @@ spec_guard: true
 spec_resource_uri: "file:///tmp/resource.txt"
 spec_prompt_name: "example_prompt"
 spec_prompt_args: '{"name":"value"}'
+# Optional: override MCP schema version used in initialize/spec guard
+spec_schema_version: "2025-11-25"
 
 # Timeouts and logging
 timeout: 30.0
@@ -110,42 +120,37 @@ mcp-fuzzer --config /path/to/config.yaml
 Use `protocol_type` in `mode: protocol` to select a specific MCP message schema
 to fuzz (for example, when you want to simulate a single request/notification
 shape rather than full protocol behavior). The canonical list lives in
-`mcp_fuzzer/fuzz_engine/executor/protocol_executor.py` under
-`ProtocolExecutor.PROTOCOL_TYPES`.
+`mcp_fuzzer/protocol_registry.py` under `EXECUTABLE_PROTOCOL_TYPES`.
 
-Accepted values:
+Accepted values (requests/notifications sent by the client):
 
 - `InitializeRequest`: Client initialization request.
-- `ProgressNotification`: Progress notification message.
-- `CancelledNotification`: Cancellation notification message.
+- `InitializedNotification`: Initialization complete notification.
+- `ListToolsRequest`: List available tools request.
+- `CallToolRequest`: Call a tool request.
 - `ListResourcesRequest`: List available resources request.
 - `ReadResourceRequest`: Read a resource by URI request.
-- `SetLevelRequest`: Set server logging level request.
-- `GenericJSONRPCRequest`: Arbitrary JSON-RPC method payload.
-- `CallToolResult`: Tool call result schema.
-- `SamplingMessage`: Sampling message payload.
-- `CreateMessageRequest`: Sampling create message request.
 - `ListPromptsRequest`: List available prompts request.
 - `GetPromptRequest`: Get a prompt by name request.
 - `ListRootsRequest`: List roots request.
-- `SubscribeRequest`: Subscribe to resource updates request.
-- `UnsubscribeRequest`: Unsubscribe from resource updates request.
+- `SetLevelRequest`: Set server logging level request.
 - `CompleteRequest`: Completion request.
 - `ListResourceTemplatesRequest`: List resource templates request.
 - `ElicitRequest`: Elicitation request.
 - `PingRequest`: Ping request.
-- `InitializeResult`: Initialization result schema.
-- `ListResourcesResult`: List resources result schema.
-- `ListResourceTemplatesResult`: List resource templates result schema.
-- `ReadResourceResult`: Read resource result schema.
-- `ListPromptsResult`: List prompts result schema.
-- `GetPromptResult`: Get prompt result schema.
-- `ListToolsResult`: List tools result schema.
-- `CompleteResult`: Completion result schema.
-- `CreateMessageResult`: Create message result schema.
-- `ListRootsResult`: List roots result schema.
-- `PingResult`: Ping result schema.
-- `ElicitResult`: Elicitation result schema.
+- `SubscribeRequest`: Subscribe to resource updates request.
+- `UnsubscribeRequest`: Unsubscribe from resource updates request.
+- `CreateMessageRequest`: Sampling create message request.
+- `ListTasksRequest`: List tasks request.
+- `GetTaskRequest`: Get task request.
+- `GetTaskPayloadRequest`: Get task payload request.
+- `CancelTaskRequest`: Cancel task request.
+- `ProgressNotification`: Progress notification message.
+- `CancelledNotification`: Cancellation notification message.
+- `GenericJSONRPCRequest`: Arbitrary JSON-RPC method payload.
+
+Result schemas are validated via spec guard but are not valid `protocol_type`
+values.
 
 ## Environment Variables
 
@@ -159,6 +164,7 @@ The following environment variables are currently read at startup:
 - `MCP_FUZZER_SSE_TIMEOUT`
 - `MCP_FUZZER_STDIO_TIMEOUT`
 - `MCP_FUZZER_ICON_THEME` (ascii | unicode | emoji; defaults to ascii)
+- `MCP_SPEC_SCHEMA_VERSION` (e.g., 2025-11-25)
 
 ## Migration From Pre-Redesign Configs (<=3d61ee4)
 
@@ -212,7 +218,9 @@ export_html: "reports/results.html"
 ```
 
 Standardized output files are currently emitted as JSON regardless of
-`output.format`; other values are reserved for future formats.
+`output.format`; other values are reserved for future formats. Only
+`fuzzing_results`, `safety_summary`, and `error_report` are emitted today;
+`performance_metrics` and `configuration_dump` are reserved.
 
 ## Authentication Configuration
 

--- a/docs/configuration/network-policy.md
+++ b/docs/configuration/network-policy.md
@@ -22,42 +22,16 @@ from urllib.parse import urlparse
 import ipaddress
 
 def _normalize_host(host: str) -> str:
-    """Normalize host to handle URLs, mixed case, etc."""
+    """Normalize host to handle URLs, mixed case, and host:port."""
     if not host:
         return ""
     s = host.strip().lower()
-    # Accept bare host or URL; extract hostname if URL-like
     if "://" in s:
         parsed = urlparse(s)
-        host = (parsed.hostname or "").strip().lower()
+        host = parsed.hostname or s
     else:
-        # Handle bracketed IPv6 like "[::1]:8080"
-        if s.startswith("["):
-            end = s.find("]")
-            host = s[1:end] if end != -1 else s
-        else:
-            # Handle unbracketed forms:
-            # 1) Plain IPv6 literal (multiple colons, no port)
-            # 2) IPv6 with trailing :port (non-standard but seen in the wild)
-            if s.count(":") > 1:
-                # Try to split off a trailing port only if it looks like one
-                left, sep, right = s.rpartition(":")
-                if sep and right.isdigit():
-                    try:
-                        port = int(right)
-                        if 0 <= port <= 65535 and isinstance(ipaddress.ip_address(left), ipaddress.IPv6Address):
-                            host = left
-                        else:
-                            host = s
-                    except ValueError:
-                        host = s
-                else:
-                    host = s
-            else:
-                # Otherwise, treat as hostname[:port]
-                host = s.split(":", 1)[0]
-    # Normalize trailing dot for FQDNs
-    return host.rstrip(".")
+        host = s.split(":", 1)[0] if ":" in s and not s.startswith("[") else s
+    return host.strip().lower()
 ```
 
 This ensures:
@@ -71,7 +45,7 @@ This ensures:
 
 The system enforces access control with the following features:
 
-- **Default-deny policy**: Only explicitly allowed hosts can be contacted
+- **Opt-in deny policy**: When enabled, only allowed hosts can be contacted
 - **Local host allowlist**: Standard local addresses (localhost, 127.0.0.1, etc.)
 - **Runtime configuration**: Dynamically adjust policy at runtime
 - **Additional allowed hosts**: Add specific hosts to the allowlist
@@ -124,14 +98,10 @@ The system uses these default settings:
 SAFETY_LOCAL_HOSTS = [
     "localhost", "127.0.0.1", "::1"
 ]
-SAFETY_NO_NETWORK_DEFAULT = True
+SAFETY_NO_NETWORK_DEFAULT = False
 
-# (Optional, recommended) Example explicit blocks to mitigate SSRF:
-# SAFETY_BLOCKED_CIDRS = [
-#   "0.0.0.0/8", "10.0.0.0/8", "100.64.0.0/10", "127.0.0.0/8",
-#   "169.254.0.0/16", "172.16.0.0/12", "192.168.0.0/16",
-#   "::/128", "::1/128", "fc00::/7", "fe80::/10"
-# ]
+# No CIDR denylist is enforced today; use `--no-network` + `--allow-host`
+# for explicit control.
 ```
 
 ### Runtime Configuration

--- a/docs/configuration/network-policy.md
+++ b/docs/configuration/network-policy.md
@@ -19,7 +19,6 @@ The system automatically normalizes host strings in a consistent way:
 
 ```python
 from urllib.parse import urlparse
-import ipaddress
 
 def _normalize_host(host: str) -> str:
     """Normalize host to handle URLs, mixed case, and host:port."""
@@ -31,7 +30,7 @@ def _normalize_host(host: str) -> str:
         host = parsed.hostname or s
     else:
         host = s.split(":", 1)[0] if ":" in s and not s.startswith("[") else s
-    return host.strip().lower()
+    return host.strip().lower().rstrip(".")
 ```
 
 This ensures:
@@ -39,6 +38,7 @@ This ensures:
 - Protocol handling (`http://example.com` -> `example.com`)
 - Port stripping (`example.com:80` -> `example.com`)
 - Whitespace handling (`  example.com  ` -> `example.com`)
+- Trailing-dot normalization (`example.com.` -> `example.com`)
 - Special cases for IPv6 addresses
 
 ### Network Access Control

--- a/docs/configuration/network-policy.md
+++ b/docs/configuration/network-policy.md
@@ -28,8 +28,15 @@ def _normalize_host(host: str) -> str:
     if "://" in s:
         parsed = urlparse(s)
         host = parsed.hostname or s
+    elif s.startswith("["):
+        end = s.find("]")
+        host = s[1:end] if end != -1 else s.strip("[]")
+    elif s.count(":") == 1:
+        host = s.split(":", 1)[0]
+    elif ":" in s:
+        host = s
     else:
-        host = s.split(":", 1)[0] if ":" in s and not s.startswith("[") else s
+        host = s
     return host.strip().lower().rstrip(".")
 ```
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -206,8 +206,8 @@ End-to-end tests often spawn local MCP servers and can trigger external
 processes. Use the same safety features that the CLI exposes when running tests
 manually:
 
-- Set `MCP_FUZZER_SAFETY_ENABLED=true` (or pass `--enable-safety-system` to CLI
-  invocations inside tests) so argument filtering stays active.
+- Argument-level safety hooks are enabled by default; avoid `--no-safety`.
+  Use `--enable-safety-system` when you need system command blocking.
 - Provide a dedicated sandbox directory via `MCP_FUZZER_FS_ROOT` or `--fs-root`
   to contain any files created by tools under test.
 - When you intentionally disable safety (for example, to fuzz filesystem-heavy
@@ -395,7 +395,7 @@ class CustomToolStrategy:
 
 To introduce new safety capabilities:
 
-1. **Extend or wrap `SafetyFilter`** (for argument-level filtering) or add helpers
+1. **Extend or wrap `SafetyFilter`** (for argument-level safety hooks) or add helpers
    under `safety_system/blocking`, `detection`, or `filesystem` as appropriate.
 2. **Expose configuration hooks** (CLI flags or config file entries) when needed.
 3. **Write unit tests** covering the new patterns, shims, or sandbox behaviors.
@@ -714,7 +714,9 @@ def analyze_fuzzing_report(report_path):
             print(f"  - {operation['operation']}: {operation['reason']}")
 
 # Usage
-analyze_fuzzing_report("reports/fuzzing_report_20250812_143000.json")
+analyze_fuzzing_report(
+    "reports/fuzzing_report_550e8400-e29b-41d4-a716-446655440000.json"
+)
 ```
 
 #### Safety Report Analysis
@@ -749,7 +751,9 @@ def analyze_safety_report(safety_report_path):
         print(f"  - {block['timestamp']}: {block['operation']}")
 
 # Usage
-analyze_safety_report("reports/safety_report_20250812_143000.json")
+analyze_safety_report(
+    "reports/safety_report_550e8400-e29b-41d4-a716-446655440000.json"
+)
 ```
 
 #### Programmatic Report Creation
@@ -856,8 +860,8 @@ def compare_reports(report1_path, report2_path):
 
 # Usage
 compare_reports(
-    "reports/fuzzing_report_20250812_143000.json",
-    "reports/fuzzing_report_20250812_150000.json"
+    "reports/fuzzing_report_550e8400-e29b-41d4-a716-446655440000.json",
+    "reports/fuzzing_report_1f4d2a77-1fda-4c5a-9f8b-9c1b2b73a5a1.json"
 )
 ```
 

--- a/docs/development/exceptions.md
+++ b/docs/development/exceptions.md
@@ -13,6 +13,12 @@ Exception
     │   ├── ConnectionError
     │   ├── ResponseError
     │   └── AuthenticationError
+    │   ├── NetworkError
+    │   ├── PayloadValidationError
+    │   └── TransportRegistrationError
+    ├── AuthError
+    │   ├── AuthConfigError
+    │   └── AuthProviderError
     ├── MCPTimeoutError
     │   ├── ProcessTimeoutError
     │   └── RequestTimeoutError
@@ -23,9 +29,19 @@ Exception
     ├── ServerError
     │   ├── ServerUnavailableError
     │   └── ProtocolError
+    ├── CLIError
+    │   └── ArgumentValidationError
+    ├── ReportError
+    │   └── ReportValidationError
     ├── ConfigurationError
     │   ├── ConfigFileError
     │   └── ValidationError
+    ├── RuntimeSubsystemError
+    │   ├── ProcessStartError
+    │   ├── ProcessStopError
+    │   ├── ProcessSignalError
+    │   ├── ProcessRegistrationError
+    │   └── WatchdogStartError
     └── FuzzingError
         ├── StrategyError
         └── ExecutorError
@@ -39,6 +55,15 @@ Exception
   - **ConnectionError**: Raised when a connection to the server cannot be established
   - **ResponseError**: Raised when the server response cannot be parsed
   - **AuthenticationError**: Raised when authentication with the server fails
+  - **NetworkError**: Raised for network policy or connectivity failures
+  - **PayloadValidationError**: Raised when a JSON-RPC payload is invalid
+  - **TransportRegistrationError**: Raised when transport registration/selection fails
+
+### Authentication Exceptions
+
+- **AuthError**: Base class for authentication subsystem errors
+  - **AuthConfigError**: Raised for invalid authentication configuration
+  - **AuthProviderError**: Raised when an auth provider definition is invalid
 
 ### Timeout-related Exceptions
 
@@ -70,6 +95,25 @@ Exception
 - **FuzzingError**: Base class for errors during fuzzing operations
   - **StrategyError**: Raised when a fuzzing strategy encounters an error
   - **ExecutorError**: Raised when the async executor encounters an error
+
+### CLI Exceptions
+
+- **CLIError**: Base class for CLI errors
+  - **ArgumentValidationError**: Raised when CLI arguments are invalid
+
+### Reporting Exceptions
+
+- **ReportError**: Base class for reporting/output errors
+  - **ReportValidationError**: Raised when report/output validation fails
+
+### Runtime Exceptions
+
+- **RuntimeSubsystemError**: Base class for runtime management errors
+  - **ProcessStartError**: Failed to start a managed process
+  - **ProcessStopError**: Failed to stop a managed process
+  - **ProcessSignalError**: Failed to send a signal to a process
+  - **ProcessRegistrationError**: Failed to register/unregister a process
+  - **WatchdogStartError**: Failed to start the watchdog
 
 ## Handling Exceptions
 

--- a/docs/development/reference.md
+++ b/docs/development/reference.md
@@ -22,6 +22,7 @@ mcp-fuzzer [OPTIONS] --mode {tools|protocol|resources|prompts|all} --protocol {h
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
+| `--config` | Path | - | Path to YAML configuration file |
 | `--validate-config` | Path | - | Validate configuration file and exit |
 | `--check-env` | Flag | False | Validate environment variables and exit |
 
@@ -38,6 +39,11 @@ mcp-fuzzer [OPTIONS] --mode {tools|protocol|resources|prompts|all} --protocol {h
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--timeout` | Float | 30.0 | Request timeout in seconds |
+| `--transport-retries` | Integer | 1 | Total attempts for transport requests (1 disables retries) |
+| `--transport-retry-delay` | Float | 0.5 | Base delay between transport retries (seconds) |
+| `--transport-retry-backoff` | Float | 2.0 | Backoff multiplier for transport retry delay |
+| `--transport-retry-max-delay` | Float | 5.0 | Maximum delay between retries (seconds) |
+| `--transport-retry-jitter` | Float | 0.1 | Jitter factor for retry delay |
 | `--auth-config` | Path | - | Path to authentication configuration file |
 | `--auth-env` | Flag | False | Use authentication from environment variables |
 
@@ -54,9 +60,20 @@ Notes:
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--phase` | Choice | aggressive | Fuzzing phase: `realistic`, `aggressive`, or `both` |
+| `--protocol-phase` | Choice | realistic | Protocol fuzzing phase: `realistic` or `aggressive` |
 | `--runs` | Integer | 10 | Number of fuzzing runs per tool (tool mode only) |
 | `--runs-per-type` | Integer | 5 | Number of runs per protocol/resource/prompt type |
+| `--tool` | String | - | Fuzz only a specific tool (tool mode only) |
 | `--protocol-type` | String | - | Fuzz only a specific protocol type (protocol mode only; required by the CLI when using `--mode protocol`) |
+| `--stateful` | Flag | False | Enable learned stateful protocol sequences (runs after protocol/resources/prompts) |
+| `--stateful-runs` | Integer | 5 | Number of learned stateful sequences to run |
+| `--corpus` / `--no-corpus` | Flag | True | Enable/disable per-target corpus save/load |
+| `--havoc` | Flag | False | Enable stacked corpus mutations (havoc mode) |
+
+Notes:
+
+- `--phase` applies to tool fuzzing. `--protocol-phase` applies to protocol,
+  resources, prompts, and stateful sequences.
 
 ### Spec Guard Options
 
@@ -66,13 +83,14 @@ Notes:
 | `--spec-resource-uri` | String | - | Resource URI used for spec guard resources/read checks |
 | `--spec-prompt-name` | String | - | Prompt name used for spec guard prompts/get checks |
 | `--spec-prompt-args` | String | - | JSON string of prompt arguments for spec guard prompts/get checks |
+| `--spec-schema-version` | String | - | Override MCP schema version used for initialize/spec guard (e.g., 2025-11-25) |
 
 ### Safety Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--enable-safety-system` | Flag | False | Enable system-level safety features |
-| `--no-safety` | Flag | False | Disable argument-level safety filtering |
+| `--no-safety` | Flag | False | Disable argument-level safety hooks |
 | `--fs-root` | Path | ~/.mcp_fuzzer | Restrict filesystem operations to specified directory |
 | `--retry-with-safety-on-interrupt` | Flag | False | Retry once with safety system enabled on Ctrl-C |
 
@@ -91,14 +109,17 @@ Notes:
 | `--safety-report` | Flag | False | Show comprehensive safety report at end of fuzzing |
 | `--export-safety-data` | String | - | Export safety data to JSON file (optional filename) |
 | `--output-format` | Choice | json | Output format for standardized reports |
-| `--output-types` | List | - | Output types to generate (fuzzing_results, error_report, safety_summary, performance_metrics, configuration_dump) |
+| `--output-types` | List | - | Output types to generate (fuzzing_results, error_report, safety_summary; performance_metrics/configuration_dump reserved) |
 | `--output-schema` | Path | - | Path to custom output schema file |
 | `--output-compress` | Flag | False | Compress output files |
 | `--output-session-id` | String | - | Custom session ID for output files |
 
 Notes:
 
-- Standardized output files are currently emitted as JSON regardless of `--output-format`; other values are reserved for future formats.
+- Standardized output files are currently emitted as JSON regardless of
+  `--output-format`; other values are reserved for future formats.
+- `--output-schema` and `--output-session-id` are parsed today but not yet
+  applied by the output writer.
 
 ### Export Options
 
@@ -142,6 +163,8 @@ Notes:
 | `MCP_FUZZER_HTTP_TIMEOUT` | 30.0 | HTTP transport timeout |
 | `MCP_FUZZER_SSE_TIMEOUT` | 30.0 | SSE transport timeout |
 | `MCP_FUZZER_STDIO_TIMEOUT` | 30.0 | Stdio transport timeout |
+| `MCP_FUZZER_ICON_THEME` | ascii | Icon theme (ascii, unicode, emoji) |
+| `MCP_SPEC_SCHEMA_VERSION` | 2025-11-25 | MCP schema version used in initialize/spec guard |
 
 ### Authentication Environment Variables
 
@@ -623,16 +646,15 @@ mcp-fuzzer --mode tools --protocol stdio --endpoint "python server.py" --enable-
 
 #### Rich Console Output
 
-Enhanced console output with better formatting:
+The CLI uses Rich tables for startup configuration and summary output:
 
 ```bash
-# Colorized output with better table formatting
+# Startup configuration table + summary tables (when available)
 mcp-fuzzer --mode tools --protocol http --endpoint http://localhost:8000 --runs 10
 # Output includes:
-# - Color-coded success/failure indicators
-# - Progress bars for long operations
-# - Formatted tables with proper alignment
-# - Summary statistics with visual indicators
+# - Startup configuration table
+# - Tool/protocol summary tables (if results are present)
+# - Safety summary tables when --safety-report is enabled
 ```
 
 #### Report Generation
@@ -646,78 +668,45 @@ mcp-fuzzer --mode tools --protocol stdio --endpoint "python server.py" --runs 20
     --export-safety-data \
     --output-dir "detailed_reports"
 # Generates:
-# - Comprehensive JSON report with metadata
-# - Human-readable text summary
-# - Safety-specific report with risk analysis
-# - Session metadata and configuration
+# - fuzzing_report_<session_id>.json (full structured report)
+# - fuzzing_report_<session_id>.txt (human-readable summary)
+# - safety_report_<session_id>.json (if --export-safety-data is enabled)
+# - Standardized JSON outputs under reports/sessions/<session_id>/...
 ```
 
 ### Configuration Validation
 
 #### Environment Variable Validation
 
-The CLI validates environment variables and provides helpful messages:
+Environment variables are validated only when `--check-env` is provided. The
+validation set is defined in `mcp_fuzzer/env.py`.
 
 ```bash
-# Invalid environment variable detection
-export MCP_FUZZER_TIMEOUT="invalid"
-mcp-fuzzer --mode tools --protocol http --endpoint http://localhost:8000
-# Error: Invalid timeout value 'invalid'. Must be a positive number.
-#        Current value: MCP_FUZZER_TIMEOUT=invalid
-#        Suggested fix: export MCP_FUZZER_TIMEOUT=30.0
+# Validate known environment variables
+mcp-fuzzer --check-env
 ```
 
 #### Configuration File Validation
 
-Enhanced configuration file validation:
+`--validate-config` checks YAML parseability and that the top-level value is a
+mapping/object. It does not perform schema validation.
 
 ```bash
 # Configuration file validation
-mcp-fuzzer --mode tools --config invalid_config.yaml
-# Error: Configuration file validation failed:
-#        - Line 5: 'timeout' must be a number, got 'invalid'
-#        - Line 10: 'protocol' must be one of ['http', 'sse', 'stdio', 'streamablehttp']
-#        Suggested fixes:
-#        - Fix timeout value on line 5
-#        - Use valid protocol on line 10
+mcp-fuzzer --validate-config config.yaml
 ```
 
 ### Performance Monitoring
 
-#### Real-time Performance Metrics
-
-The CLI provides real-time performance monitoring:
-
-```bash
-# Performance monitoring during execution
-mcp-fuzzer --mode tools --protocol http --endpoint http://localhost:8000 --runs 100 --verbose
-# Output includes:
-# - Requests per second
-# - Average response time
-# - Memory usage
-# - CPU usage
-# - Error rate trends
-```
-
-#### Resource Usage Reporting
-
-Enhanced resource usage reporting:
-
-```bash
-# Resource usage summary
-mcp-fuzzer --mode tools --protocol stdio --endpoint "python server.py" --runs 50
-# Output: "Resource usage summary:"
-#         "  CPU usage: 15.2% average"
-#         "  Memory usage: 45.3 MB peak"
-#         "  Network I/O: 2.1 MB total"
-#         "  Process count: 3 managed"
-```
+There is no built-in real-time performance metrics stream today. Use external
+tools (e.g., `top`, `ps`, or `psutil` in a wrapper) if you need CPU/memory
+reporting.
 
 ### Debugging and Troubleshooting
 
 #### Enhanced Debug Output
 
-Improved debug output for troubleshooting:
+Debug logging provides deeper visibility into runtime behavior:
 
 ```bash
 # Debug mode with detailed information
@@ -725,8 +714,7 @@ mcp-fuzzer --mode tools --protocol http --endpoint http://localhost:8000 --log-l
 # Output includes:
 # - Detailed request/response logging
 # - Safety system decision logging
-# - Process management events
-# - Performance timing information
+# - Transport retries and process management events
 ```
 
 #### Diagnostic Information
@@ -799,7 +787,7 @@ Notes:
 
 For detailed fuzzing results and security analysis of popular open source MCP servers, see the [Fuzz Results](../testing/fuzz-results.md) documentation.
 
-This section provides comprehensive testing results for various MCP server implementations, including vulnerability assessments, performance metrics, and security recommendations.
+This section provides testing results for various MCP server implementations, including vulnerability assessments and security recommendations.
 
 ## API Reference
 
@@ -1057,16 +1045,14 @@ safety.set_fs_root("/tmp/mcp_sandbox")
 
 tool_args = {"url": "https://example.com", "output_path": "/etc/passwd"}
 sanitized = safety.sanitize_tool_arguments("web_tool", tool_args)
-
-if safety.should_skip_tool_call("web_tool", tool_args):
-    safe_response = safety.create_safe_mock_response("web_tool")
-else:
-    # Proceed with sanitized arguments
-    transport.call_tool("web_tool", sanitized)
+# Proceed with sanitized arguments (filesystem paths are rewritten if sandboxed)
+transport.call_tool("web_tool", sanitized)
 ```
 
-`SafetyFilter` combines the pattern-based `DangerDetector`, filesystem path
-sanitization, and blocked operation logging. For system-level protection call
+`SafetyFilter` provides optional filesystem path sanitization when a sandbox
+root is set and exposes `DangerDetector` helpers for custom blocking. The
+default implementation does not block URL/script/command payloads. For
+system-level protection call
 `mcp_fuzzer.safety_system.blocking.start_system_blocking()` to install PATH
 shims that intercept browser launches.
 
@@ -1120,54 +1106,39 @@ class AggressiveToolStrategy:
 
 ## Output Format
 
-### Tool Fuzzer Results
+### Report Snapshot (JSON)
 
-```python
+```json
 {
-    "tools": [
-        {
-            "name": "tool_name",
-            "success_rate": 85.0,
-            "total_runs": 10,
-            "successful_runs": 8,
-            "exception_count": 2,
-            "exceptions": [
-                "Invalid argument type",
-                "Missing required parameter"
-            ],
-            "average_response_time": 0.15
-        }
-    ],
-    "overall": {
-        "total_tools": 3,
-        "total_runs": 30,
-        "overall_success_rate": 90.0,
-        "total_exceptions": 3
-    }
-}
-```
-
-### Protocol Fuzzer Results
-
-```python
-{
-    "protocol_types": [
-        {
-            "name": "InitializeRequest",
-            "total_runs": 5,
-            "successful_runs": 5,
-            "exception_count": 0,
-            "success_rate": 100.0,
-            "exceptions": [],
-            "average_response_time": 0.12
-        }
-    ],
-    "overall": {
-        "total_protocol_types": 19,
-        "total_runs": 95,
-        "overall_success_rate": 93.3,
-        "total_exceptions": 5
-    }
+  "metadata": {
+    "session_id": "550e8400-e29b-41d4-a716-446655440000",
+    "mode": "tools",
+    "protocol": "stdio",
+    "endpoint": "python server.py",
+    "runs": 10,
+    "runs_per_type": null,
+    "fuzzer_version": "1.0.0",
+    "start_time": "2025-01-01T00:00:00Z",
+    "end_time": "2025-01-01T00:00:10Z"
+  },
+  "tool_results": {
+    "example_tool": [
+      {"run": 1, "success": true, "args": {"param": "value"}},
+      {"run": 2, "success": false, "exception": "Invalid argument"}
+    ]
+  },
+  "protocol_results": {
+    "InitializeRequest": [
+      {"success": true, "result": {"response": {"result": {}}}}
+    ]
+  },
+  "summary": {
+    "tools": {"total_tools": 1, "total_runs": 2, "success_rate": 50.0},
+    "protocols": {"total_protocol_types": 1, "total_runs": 1, "success_rate": 100.0}
+  },
+  "spec_summary": {},
+  "safety": {},
+  "runtime": {}
 }
 ```
 
@@ -1175,10 +1146,10 @@ class AggressiveToolStrategy:
 
 The safety system focuses on containment and preventing external references during fuzzing.
 
-- Argument-level filtering (`mcp_fuzzer.safety_system.safety.SafetyFilter`):
-  - Blocks URLs and risky commands in tool arguments; recursively sanitizes dicts/lists.
-  - CLI provides `--fs-root` to redirect sandbox.
-  - `set_fs_root(path)` records a sandbox root (for future path checks).
+- Argument-level hooks (`mcp_fuzzer.safety_system.safety.SafetyFilter`):
+  - Default implementation passes URL/script/command payloads through for fuzzing.
+  - Filesystem paths are sanitized when a sandbox root is set (`--fs-root`).
+  - `set_fs_root(path)` initializes the sandbox for path sanitization.
 
 - System-level blocking (`mcp_fuzzer.safety_system.blocking.command_blocker.SystemCommandBlocker`):
   - Creates PATH shims for `xdg-open`, `open`, `start`, and common browsers to prevent app launches.

--- a/docs/development/standardized-output.md
+++ b/docs/development/standardized-output.md
@@ -10,7 +10,7 @@ The standardized output format provides:
 - **Versioned Protocol**: Protocol versioning for future compatibility
 - **Machine Readable**: Easily parseable by scripts and other tools
 - **Extensible**: Support for adding new output types without breaking existing parsers
-- **Validated**: Schema validation ensures output integrity
+- **Validated**: Lightweight structural checks before saving; JSON schema is provided for external tooling
 
 ## Protocol Structure
 
@@ -44,6 +44,10 @@ All standardized outputs follow this base structure:
 
 ## Output Types
 
+Currently, the fuzzer emits `fuzzing_results`, `error_report`, and
+`safety_summary`. The `performance_metrics` and `configuration_dump` types are
+reserved and not emitted yet; their schemas may change before release.
+
 ### Fuzzing Results
 
 Contains comprehensive fuzzing results including tool and protocol test outcomes.
@@ -69,7 +73,7 @@ Contains comprehensive fuzzing results including tool and protocol test outcomes
         "exceptions": 2,
         "safety_blocked": 0,
         "success_rate": 80.0,
-        "exceptions": [
+        "exception_details": [
           {
             "type": "ValueError",
             "message": "Invalid argument format",
@@ -86,7 +90,8 @@ Contains comprehensive fuzzing results including tool and protocol test outcomes
         "errors": 0,
         "success_rate": 100.0
       }
-    ]
+    ],
+    "spec_summary": {}
   },
   "metadata": {
     "execution_time": "PT2M30S",
@@ -177,63 +182,15 @@ Contains safety system statistics and blocked operations.
 }
 ```
 
-### Performance Metrics
+### Performance Metrics (Reserved)
 
-Contains timing and resource usage data.
+`performance_metrics` is reserved for future timing/resource reporting. The
+current CLI does not emit this output type.
 
-```json
-{
-  "protocol_version": "1.0.0",
-  "timestamp": "2024-01-01T00:00:00Z",
-  "tool_version": "0.1.6",
-  "session_id": "550e8400-e29b-41d4-a716-446655440000",
-  "output_type": "performance_metrics",
-  "data": {
-    "metrics": {
-      "total_execution_time": "PT5M30S",
-      "average_response_time": "PT0.5S",
-      "memory_peak_usage": "150MB",
-      "cpu_usage_percent": 75.5
-    },
-    "benchmarks": {
-      "tools_per_second": 2.1,
-      "requests_per_second": 45.8
-    }
-  },
-  "metadata": {
-    "collection_timestamp": "2024-01-01T00:00:00Z",
-    "metrics_count": 4
-  }
-}
-```
+### Configuration Dump (Reserved)
 
-### Configuration Dump
-
-Contains the current tool configuration state.
-
-```json
-{
-  "protocol_version": "1.0.0",
-  "timestamp": "2024-01-01T00:00:00Z",
-  "tool_version": "0.1.6",
-  "session_id": "550e8400-e29b-41d4-a716-446655440000",
-  "output_type": "configuration_dump",
-  "data": {
-    "configuration": {
-      "mode": "tools",
-      "protocol": "http",
-      "endpoint": "http://localhost:8000",
-      "timeout": 30.0,
-      "runs": 10
-    },
-    "source": "runtime"
-  },
-  "metadata": {
-    "config_keys_count": 5,
-    "dump_timestamp": "2024-01-01T00:00:00Z"
-  }
-}
-```
+`configuration_dump` is reserved for future configuration snapshot exports. The
+current CLI does not emit this output type.
 
 ## CLI Options
 
@@ -253,6 +210,10 @@ mcp-fuzzer --output-compress
 mcp-fuzzer --output-session-id my-session-123
 ```
 
+Note: standardized outputs are always written as JSON today. `--output-format`,
+`--output-schema`, and `--output-session-id` are parsed but not yet applied by
+the output writer.
+
 ### Configuration File
 
 Output settings can be configured via YAML configuration file:
@@ -260,16 +221,13 @@ Output settings can be configured via YAML configuration file:
 ```yaml
 output:
   format: json
-  directory: ./output
-  compression: true
+  directory: ./reports
+  compress: true
   types:
     - fuzzing_results
     - error_report
     - safety_summary
   schema: ./schemas/output_v1.json
-  retention:
-    days: 30
-    max_size: "1GB"
 ```
 
 ## File Organization
@@ -277,31 +235,25 @@ output:
 ### Directory Structure
 
 ```
-output/
+reports/
 ├── sessions/
 │   └── {session_id}/
 │       ├── 20240101_000000_fuzzing_results.json
 │       ├── 20240101_000001_error_report.json
 │       └── 20240101_000002_safety_summary.json
-└── reports/
-    ├── daily/
-    ├── weekly/
-    └── monthly/
 ```
 
 ### Naming Conventions
 
-- **Session-based**: `{timestamp}_{session_id}_{type}.{format}`
-- **Time-based**: `{date}_{type}_{summary}.{format}`
-- **Custom**: User-defined naming patterns
+- **Session-based**: `sessions/{session_id}/{timestamp}_{output_type}.json`
 
 Example filenames:
-- `20240101_000000_550e8400-e29b-41d4-a716-446655440000_fuzzing_results.json`
-- `2024-01-01_fuzzing_summary.json`
+- `sessions/550e8400-e29b-41d4-a716-446655440000/20240101_000000_fuzzing_results.json`
+- `sessions/550e8400-e29b-41d4-a716-446655440000/20240101_000001_error_report.json`
 
 ## Schema Validation
 
-All outputs are validated against the protocol schema before saving. Invalid outputs will raise a `ValidationError`.
+Outputs are validated for required fields and valid `output_type` before saving. The JSON schema is provided for external tooling; invalid outputs raise a `ValidationError`.
 
 ```python
 from mcp_fuzzer.reports.output import OutputProtocol
@@ -310,7 +262,7 @@ protocol = OutputProtocol()
 output = protocol.create_fuzzing_results_output(...)
 
 if protocol.validate_output(output):
-    filepath = protocol.save_output(output, "./output")
+    filepath = protocol.save_output(output, "./reports")
 ```
 
 ## Integration Examples
@@ -325,11 +277,12 @@ mcp-fuzzer --mode all --output-types fuzzing_results,error_report --output-forma
 # Parse results in CI/CD
 python -c "
 import json
-with open('output/sessions/*/fuzzing_results.json') as f:
-    data = json.load(f)
-    success_rate = data['metadata']['success_rate']
-    if success_rate < 80:
-        exit(1)
+from pathlib import Path
+path = next(Path('reports/sessions').rglob('*_fuzzing_results.json'))
+data = json.loads(path.read_text())
+success_rate = data['metadata']['success_rate']
+if success_rate < 80:
+    exit(1)
 "
 ```
 
@@ -339,7 +292,7 @@ with open('output/sessions/*/fuzzing_results.json') as f:
 from mcp_fuzzer.reports.output import OutputManager
 
 # Create output manager
-manager = OutputManager("./output")
+manager = OutputManager("./reports")
 
 # Generate and save results
 filepath = manager.save_fuzzing_results(
@@ -380,7 +333,7 @@ def parse_fuzzing_results(filepath):
 
 # Process all results
 results = []
-for file in Path("./output/sessions").rglob("*fuzzing_results.json"):
+for file in Path("./reports/sessions").rglob("*fuzzing_results.json"):
     results.append(parse_fuzzing_results(file))
 ```
 
@@ -450,8 +403,8 @@ Each `output_type` maps to a data payload:
 - `fuzzing_results`: mode, protocol, endpoint, tool/protocol summaries, spec summary.
 - `error_report`: list of errors + warnings, execution context.
 - `safety_summary`: blocked operations, safety statistics, risk assessment.
-- `performance_metrics`: metrics and benchmarks.
-- `configuration_dump`: resolved configuration snapshot.
+- `performance_metrics`: reserved (not emitted yet).
+- `configuration_dump`: reserved (not emitted yet).
 
 ## API Reference
 

--- a/docs/getting-started/examples.md
+++ b/docs/getting-started/examples.md
@@ -210,17 +210,14 @@ mcp-fuzzer --mode tools --phase realistic --protocol http --endpoint http://loca
 mcp-fuzzer --mode tools --phase aggressive --protocol http --endpoint http://localhost:8000 --runs 20
 ```
 
-#### Protocol Fuzzing with Both Phases
+#### Protocol Fuzzing Phases
 
 ```bash
-# Two-phase protocol fuzzing
-mcp-fuzzer --mode protocol --protocol-type InitializeRequest --phase both --protocol http --endpoint http://localhost:8000 --runs-per-type 10
-
-# Realistic protocol testing
-mcp-fuzzer --mode protocol --protocol-type InitializeRequest --phase realistic --protocol http --endpoint http://localhost:8000 --runs-per-type 8
+# Realistic protocol testing (default)
+mcp-fuzzer --mode protocol --protocol-type InitializeRequest --protocol-phase realistic --protocol http --endpoint http://localhost:8000 --runs-per-type 8
 
 # Aggressive protocol testing
-mcp-fuzzer --mode protocol --protocol-type InitializeRequest --phase aggressive --protocol http --endpoint http://localhost:8000 --runs-per-type 15
+mcp-fuzzer --mode protocol --protocol-type InitializeRequest --protocol-phase aggressive --protocol http --endpoint http://localhost:8000 --runs-per-type 15
 ```
 
 ## Configuration Examples
@@ -268,7 +265,7 @@ mcp-fuzzer --mode protocol --protocol-type InitializeRequest --protocol http --e
 mcp-fuzzer --mode tools --phase realistic --protocol http --endpoint https://api.example.com --runs 10
 
 # Test protocol compliance
-mcp-fuzzer --mode protocol --protocol-type InitializeRequest --phase realistic --protocol http --endpoint https://api.example.com --runs-per-type 5
+mcp-fuzzer --mode protocol --protocol-type InitializeRequest --protocol-phase realistic --protocol http --endpoint https://api.example.com --runs-per-type 5
 
 # Test with authentication
 mcp-fuzzer --mode tools --phase realistic --protocol http --endpoint https://api.example.com --auth-config auth.json
@@ -281,11 +278,11 @@ mcp-fuzzer --mode tools --phase realistic --protocol http --endpoint https://api
 mcp-fuzzer --mode tools --phase aggressive --protocol http --endpoint http://localhost:8000 --runs 25
 
 # Protocol security testing
-mcp-fuzzer --mode protocol --protocol-type InitializeRequest --phase aggressive --protocol http --endpoint http://localhost:8000 --runs-per-type 15
+mcp-fuzzer --mode protocol --protocol-type InitializeRequest --protocol-phase aggressive --protocol http --endpoint http://localhost:8000 --runs-per-type 15
 
 # Combined security testing
 mcp-fuzzer --mode tools --phase aggressive --protocol http --endpoint http://localhost:8000 --runs 20
-mcp-fuzzer --mode protocol --protocol-type InitializeRequest --phase aggressive --protocol http --endpoint http://localhost:8000 --runs-per-type 10
+mcp-fuzzer --mode protocol --protocol-type InitializeRequest --protocol-phase aggressive --protocol http --endpoint http://localhost:8000 --runs-per-type 10
 ```
 
 ## Reporting Examples
@@ -318,13 +315,18 @@ mcp-fuzzer --mode tools --protocol stdio --endpoint "python test_server.py" --ru
 
 ### Generated Report Files
 
-Each fuzzing session creates timestamped reports:
+Each fuzzing session creates session-id based reports plus standardized outputs:
 
 ```text
 reports/
-| -- fuzzing_report_20250812_143000.json    # Complete structured data
-| -- fuzzing_report_20250812_143000.txt     # Human-readable summary
-| -- safety_report_20250812_143000.json     # Safety system data
+|-- fuzzing_report_550e8400-e29b-41d4-a716-446655440000.json    # Complete structured report
+|-- fuzzing_report_550e8400-e29b-41d4-a716-446655440000.txt     # Human-readable summary
+|-- safety_report_550e8400-e29b-41d4-a716-446655440000.json     # Safety system data (if enabled)
+|-- sessions/
+|   |-- 550e8400-e29b-41d4-a716-446655440000/
+|   |   |-- 20240101_000000_fuzzing_results.json
+|   |   |-- 20240101_000001_error_report.json     # When --output-types includes error_report
+|   |   |-- 20240101_000002_safety_summary.json   # When safety reporting is enabled
 ```
 
 ### Report Content Examples
@@ -333,7 +335,7 @@ reports/
 ```json
 {
   "metadata": {
-    "session_id": "20250812_143000",
+    "session_id": "550e8400-e29b-41d4-a716-446655440000",
     "start_time": "2025-08-12T14:30:00.123456",
     "mode": "tools",
     "protocol": "stdio",
@@ -366,7 +368,7 @@ MCP FUZZER REPORT
 
 FUZZING SESSION METADATA
 ----------------------------------------
-session_id: 20250812_143000
+session_id: 550e8400-e29b-41d4-a716-446655440000
 start_time: 2025-08-12T14:30:00.123456
 mode: tools
 protocol: stdio

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -72,6 +72,8 @@ First, ensure you have an MCP server running. You can use any of these transport
 
 - **Stdio**: `python test_server.py`
 
+- **StreamableHTTP**: `http://localhost:8000/mcp` (use `--protocol streamablehttp`)
+
 ### 2. Run Basic Fuzzing
 
 #### Tool Fuzzing (Default Mode)
@@ -110,6 +112,8 @@ mcp-fuzzer --mode protocol --protocol-type InitializeRequest --protocol http --e
 mcp-fuzzer --mode protocol --protocol-type InitializeRequest --protocol http --endpoint http://localhost:8000 --runs-per-type 5 --verbose
 ```
 
+Use `--protocol-phase aggressive` when you want malformed protocol payloads.
+
 ### 3. View Results
 
 Results are displayed in beautiful, colorized tables showing:
@@ -138,10 +142,14 @@ mcp-fuzzer --mode tools --protocol stdio --endpoint "python test_server.py" --ru
 mcp-fuzzer --mode tools --protocol stdio --endpoint "python test_server.py" --runs 10 --export-safety-data
 ```
 
-Each fuzzing session creates timestamped reports:
-- **`fuzzing_report_YYYYMMDD_HHMMSS.json`** - Complete structured data for analysis
-- **`fuzzing_report_YYYYMMDD_HHMMSS.txt`** - Human-readable summary for sharing
-- **`safety_report_YYYYMMDD_HHMMSS.json`** - Detailed safety system data (if enabled)
+Each fuzzing session creates session-id based reports:
+- **`fuzzing_report_<session_id>.json`** - Complete structured data for analysis
+- **`fuzzing_report_<session_id>.txt`** - Human-readable summary for sharing
+- **`safety_report_<session_id>.json`** - Detailed safety system data (if enabled)
+
+Standardized JSON outputs are also written under
+`reports/sessions/<session_id>/` with timestamped filenames (for example,
+`*_fuzzing_results.json`).
 
 ## Configuration
 
@@ -165,6 +173,10 @@ fs_root: "~/.mcp_fuzzer"
 ```
 
 ## Fuzzing Modes
+
+Tool fuzzing uses `--phase` (`realistic`, `aggressive`, or `both`). Protocol,
+resource, prompt, and stateful fuzzing use `--protocol-phase` (`realistic` or
+`aggressive`, default: `realistic`).
 
 ### Tool Fuzzing Mode
 
@@ -196,10 +208,34 @@ mcp-fuzzer --mode protocol --protocol-type InitializeRequest --protocol http --e
 mcp-fuzzer --mode protocol --protocol-type InitializeRequest --protocol http --endpoint http://localhost:8000
 
 # Realistic protocol fuzzing
-mcp-fuzzer --mode protocol --protocol-type InitializeRequest --phase realistic --protocol http --endpoint http://localhost:8000
+mcp-fuzzer --mode protocol --protocol-type InitializeRequest --protocol-phase realistic --protocol http --endpoint http://localhost:8000
 
 # Aggressive protocol fuzzing
-mcp-fuzzer --mode protocol --protocol-type InitializeRequest --phase aggressive --protocol http --endpoint http://localhost:8000
+mcp-fuzzer --mode protocol --protocol-type InitializeRequest --protocol-phase aggressive --protocol http --endpoint http://localhost:8000
+```
+
+### Resource and Prompt Modes
+
+These modes run spec-guard checks (unless `--spec-guard` is disabled) and then
+fuzz the related request types.
+
+```bash
+# Resource endpoints
+mcp-fuzzer --mode resources --protocol http --endpoint http://localhost:8000 \
+  --spec-resource-uri file:///tmp/resource.txt
+
+# Prompt endpoints
+mcp-fuzzer --mode prompts --protocol http --endpoint http://localhost:8000 \
+  --spec-prompt-name summarize \
+  --spec-prompt-args '{"text":"hello"}'
+```
+
+### Stateful Sequences (Optional)
+
+```bash
+# Run learned protocol sequences after protocol fuzzing
+mcp-fuzzer --mode protocol --protocol http --endpoint http://localhost:8000 \
+  --stateful --stateful-runs 3
 ```
 
 ## Authentication
@@ -256,7 +292,7 @@ mcp-fuzzer --mode tools --auth-env --endpoint http://localhost:8000
 ### Basic Safety Features
 
 ```bash
-# Enable system command blocking (argument-level filtering is already on)
+# Enable system command blocking (argument-level safety hooks are already on)
 mcp-fuzzer --mode tools --protocol stdio --endpoint "python test_server.py" --enable-safety-system
 
 # Set filesystem root
@@ -269,13 +305,13 @@ mcp-fuzzer --mode tools --protocol stdio --endpoint "python test_server.py" --no
 
 ### Safety System Features
 
-- **System Command Blocking**: Prevents execution of dangerous commands
+- **System Command Blocking**: Prevents execution of dangerous commands when `--enable-safety-system` is set
 
-- **Filesystem Sandboxing**: Confines file operations to specified directories
+- **Filesystem Sandboxing**: Confines file operations to specified directories when `--fs-root` is set
 
-- **Process Isolation**: Safe subprocess handling with timeouts
+- **Process Management**: Safe subprocess handling with watchdog timeouts
 
-- **Dangerous Content Filtering**: URL/script/command pattern detection with mock responses
+- **Safety Hooks**: Detection helpers available if you implement custom blocking
 
 ## Reporting and Output
 
@@ -308,17 +344,20 @@ mcp-fuzzer --mode tools --protocol stdio --endpoint "python test_server.py" --ru
 
 Each fuzzing session creates:
 
-- **`fuzzing_report_YYYYMMDD_HHMMSS.json`** - Complete structured data for analysis
-- **`fuzzing_report_YYYYMMDD_HHMMSS.txt`** - Human-readable summary for sharing
-- **`safety_report_YYYYMMDD_HHMMSS.json`** - Detailed safety system data (if enabled)
+- **`fuzzing_report_<session_id>.json`** - Complete structured data for analysis
+- **`fuzzing_report_<session_id>.txt`** - Human-readable summary for sharing
+- **`safety_report_<session_id>.json`** - Detailed safety system data (if enabled)
+
+Standardized JSON outputs are also written under
+`reports/sessions/<session_id>/` with timestamped filenames.
 
 ### Report Contents
 
-- **Session metadata**: Configuration, timestamps, and execution parameters
+- **Session metadata**: Mode, protocol, endpoint, runs, and timestamps
 - **Tool results**: Success rates, exceptions, and safety blocks
-- **Protocol results**: Error counts and security ratings
+- **Protocol results**: Error counts and success rates
 - **Safety data**: Blocked operations, risk assessments, and system status
-- **Summary statistics**: Overall success rates and performance metrics
+- **Summary statistics**: Overall success rates and execution timing
 
 ## Common Use Cases
 
@@ -339,7 +378,7 @@ mcp-fuzzer --mode tools --protocol stdio --endpoint "python test_server.py" --ru
 mcp-fuzzer --mode tools --phase realistic --protocol http --endpoint https://api.example.com --runs 15
 
 # Test protocol compliance
-mcp-fuzzer --mode protocol --protocol-type InitializeRequest --phase realistic --protocol http --endpoint https://api.example.com --runs-per-type 8
+mcp-fuzzer --mode protocol --protocol-type InitializeRequest --protocol-phase realistic --protocol http --endpoint https://api.example.com --runs-per-type 8
 ```
 
 ### Security Testing
@@ -349,7 +388,7 @@ mcp-fuzzer --mode protocol --protocol-type InitializeRequest --phase realistic -
 mcp-fuzzer --mode tools --phase aggressive --protocol http --endpoint http://localhost:8000 --runs 25
 
 # Protocol security testing
-mcp-fuzzer --mode protocol --protocol-type InitializeRequest --phase aggressive --protocol http --endpoint http://localhost:8000 --runs-per-type 15
+mcp-fuzzer --mode protocol --protocol-type InitializeRequest --protocol-phase aggressive --protocol http --endpoint http://localhost:8000 --runs-per-type 15
 ```
 
 ## Troubleshooting

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -28,7 +28,7 @@ pip install -e .
 
 ### Basic Usage
 
-1. **Set up your MCP server** (HTTP, SSE, or Stdio)
+1. **Set up your MCP server** (HTTP, SSE, Stdio, or StreamableHTTP)
 2. **Run basic fuzzing**:
    ```bash
    # Fuzz tools on an HTTP server
@@ -57,15 +57,17 @@ pip install -e .
 
 - **Stdio** - Command-line interface for local testing
 
+- **StreamableHTTP** - HTTP with MCP session negotiation and streaming support
+
 ### Safety & Security
 
-- **Built-in Safety System** - Pattern-based filtering plus safety reports
+- **Safety System** - System command blocking, optional sandboxing, and safety reports
 
 - **System Command Blocking** - PATH shims stop browser/app launches
 
-- **Filesystem Sandboxing** - Confines file operations
+- **Filesystem Sandboxing** - Confines file operations when `--fs-root` is set
 
-- **Process Isolation** - Safe subprocess handling with timeouts
+- **Process Management** - Safe subprocess handling with timeouts
 
 ### Comprehensive Testing
 
@@ -87,7 +89,7 @@ pip install -e .
 
 - **Multiple Output Formats** - Console, JSON, and text for different use cases
 
-- **Session Tracking** - Timestamped reports with unique session identification
+- **Session Tracking** - Session-id based reports with timestamps in metadata
 
 ## Architecture
 
@@ -99,7 +101,7 @@ The MCP Fuzzer uses a modular architecture with clear separation of concerns:
 
 - **Strategy System** - Realistic and aggressive data generation
 
-- **Safety System** - Pattern-based filtering, sandboxing, and PATH shims
+- **Safety System** - System command blocking, optional sandboxing, and safety reports
 
 - **Reporting System** - Centralized output management and comprehensive reporting
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ pip install -e .
 
 ### Basic Usage
 
-1. **Set up your MCP server** (HTTP, SSE, or Stdio)
+1. **Set up your MCP server** (HTTP, SSE, Stdio, or StreamableHTTP)
 2. **Run basic fuzzing**:
    ```bash
    # Fuzz tools on an HTTP server
@@ -57,15 +57,17 @@ pip install -e .
 
 - **Stdio** - Command-line interface for local testing
 
+- **StreamableHTTP** - HTTP with MCP session negotiation and streaming support
+
 ### Safety & Security
 
-- **Built-in Safety System** - Pattern-based filtering plus safety reports
+- **Safety System** - System command blocking, optional sandboxing, and safety reports
 
 - **System Command Blocking** - PATH shims stop browser/app launches
 
-- **Filesystem Sandboxing** - Confines file operations
+- **Filesystem Sandboxing** - Confines file operations when `--fs-root` is set
 
-- **Process Isolation** - Safe subprocess handling with timeouts
+- **Process Management** - Safe subprocess handling with timeouts
 
 ### Comprehensive Testing
 
@@ -87,7 +89,7 @@ pip install -e .
 
 - **Multiple Output Formats** - Console, JSON, and text for different use cases
 
-- **Session Tracking** - Timestamped reports with unique session identification
+- **Session Tracking** - Session-id based reports with timestamps in metadata
 
 ## Architecture
 
@@ -102,7 +104,7 @@ The MCP Fuzzer uses a modular architecture with clear separation of concerns:
 
 - **Strategy System** - Realistic and aggressive data generation
 
-- **Safety System** - Pattern-based filtering, sandboxing, and PATH shims
+- **Safety System** - System command blocking, optional sandboxing, and safety reports
 
 - **Reporting System** - Centralized output management and comprehensive reporting
 

--- a/docs/testing/fuzz-results.md
+++ b/docs/testing/fuzz-results.md
@@ -381,11 +381,11 @@ The MCP Fuzzer provides comprehensive testing capabilities across multiple serve
 - **MCP Fuzzer:** Latest version with comprehensive safety systems
 - **Safety Features:**
   - Command blocking for dangerous system calls
-  - URL and file path sanitization
-  - Process isolation and monitoring
-  - Content filtering for malicious payloads
+  - File path sanitization when the sandbox is enabled
+  - Process management and monitoring
+  - Network policy controls when `--no-network` / `--allow-host` are used
 - **Testing Modes:** Tools, Protocol, and Combined testing
-- **Output:** Standardized reports with JSON, XML, HTML, and Markdown formats
+- **Output:** JSON reports plus optional CSV/XML/HTML/Markdown exports; standardized outputs are JSON
 
 ## How To Run These Tests
 
@@ -480,7 +480,7 @@ Our MCP fuzzing framework has proven highly effective across multiple server typ
 
 ## Key Framework Capabilities
 
-- **Safety Systems Work:** Command blocking, URL filtering, and content sanitization effectively prevent malicious operations
+- **Safety Systems Work:** Command blocking, optional filesystem sandboxing, and network policy controls help prevent dangerous side effects
 - **Comprehensive Testing:** Both tools and protocol-level testing provide thorough validation
 - **Input Validation:** Successfully detects and reports detailed validation errors across different server types
 - **Real-world Ready:** Production-ready safety features make it suitable for testing MCP servers in development and production environments

--- a/mcp_fuzzer/safety_system/policy.py
+++ b/mcp_fuzzer/safety_system/policy.py
@@ -25,6 +25,35 @@ _POLICY_DENY_NETWORK_DEFAULT_OVERRIDE: bool | None = None
 _POLICY_EXTRA_ALLOWED_HOSTS: set[str] = set()
 
 
+def _normalize_host(host: str | None) -> str:
+    """Normalize hostnames for policy comparisons."""
+    if not host:
+        return ""
+
+    s = host.strip().lower()
+    if not s:
+        return ""
+
+    # Accept full URLs and use parsed hostname when available.
+    if "://" in s:
+        parsed = urlparse(s)
+        normalized = parsed.hostname or s
+    # Handle bracketed IPv6 with optional port: [::1]:8080 -> ::1
+    elif s.startswith("["):
+        end = s.find("]")
+        if end != -1:
+            normalized = s[1:end]
+        else:
+            normalized = s.strip("[]")
+    # Handle host:port without protocol.
+    elif ":" in s:
+        normalized = s.split(":", 1)[0]
+    else:
+        normalized = s
+
+    return normalized.strip().lower().rstrip(".")
+
+
 def configure_network_policy(
     deny_network_by_default: bool | None = None,
     extra_allowed_hosts: Iterable[str] | None = None,
@@ -44,24 +73,6 @@ def configure_network_policy(
 
     if reset_allowed_hosts:
         _POLICY_EXTRA_ALLOWED_HOSTS = set()
-
-    def _normalize_host(host: str) -> str:
-        """Normalize host to handle URLs, mixed case, etc."""
-        if not host:
-            return ""
-        s = host.strip().lower()
-        # Accept bare host or URL; extract hostname if URL-like
-        if "://" in s:
-            parsed = urlparse(s)
-            host = parsed.hostname or s
-        else:
-            # For cases like "example.com:80" without protocol
-            if ":" in s and not s.startswith("["):
-                # Handle IPv6 addresses
-                host = s.split(":", 1)[0]
-            else:
-                host = s
-        return host.strip().lower()
 
     if extra_allowed_hosts is not None:
         normalized_hosts = {_normalize_host(h) for h in extra_allowed_hosts if h}
@@ -88,25 +99,19 @@ def is_host_allowed(
 
     parsed = urlparse(url)
     raw_host = parsed.hostname or ""
+    if not raw_host:
+        raw_host = url.split("/", 1)[0] if "://" not in url else url
 
-    # Normalize the host from the URL
-    if not raw_host and ":" in url and not url.startswith("["):
-        # Handle non-URL format with port
-        parts = url.split(":", 1)
-        raw_host = parts[0]
-
-    host = raw_host.lower()
+    host = _normalize_host(raw_host)
 
     # Collect and normalize all allowed hosts
-    allowed_set = set()
-    for h in allowed_hosts or SAFETY_LOCAL_HOSTS:
-        # Use same normalization logic as in configure_network_policy
-        if "://" in h:
-            h_parsed = urlparse(h)
-            norm_h = h_parsed.hostname or h
-        else:
-            norm_h = h.split(":")[0] if ":" in h and not h.startswith("[") else h
-        allowed_set.add(norm_h.lower())
+    allowed_set = {
+        normalized
+        for h in (allowed_hosts or SAFETY_LOCAL_HOSTS)
+        if h
+        for normalized in [_normalize_host(h)]
+        if normalized
+    }
 
     if _POLICY_EXTRA_ALLOWED_HOSTS:
         allowed_set |= _POLICY_EXTRA_ALLOWED_HOSTS

--- a/mcp_fuzzer/safety_system/policy.py
+++ b/mcp_fuzzer/safety_system/policy.py
@@ -46,8 +46,11 @@ def _normalize_host(host: str | None) -> str:
         else:
             normalized = s.strip("[]")
     # Handle host:port without protocol.
-    elif ":" in s:
+    elif s.count(":") == 1:
         normalized = s.split(":", 1)[0]
+    # Bare IPv6 literals contain multiple colons and should not be split.
+    elif ":" in s:
+        normalized = s
     else:
         normalized = s
 
@@ -86,8 +89,8 @@ def is_host_allowed(
 ) -> bool:
     """Return True if the URL's host is permitted by policy.
 
-    - By default, only localhost/loopback hosts are allowed.
-    - If deny_network_by_default is False, allow any host.
+    - When deny_network_by_default is True, only allowed hosts are permitted.
+    - When deny_network_by_default is False, allow any host.
     """
     # Resolve deny flag with runtime override first
     if _POLICY_DENY_NETWORK_DEFAULT_OVERRIDE is not None:

--- a/tests/e2e/test_everything_server.sh
+++ b/tests/e2e/test_everything_server.sh
@@ -110,6 +110,7 @@ python3 -m mcp_fuzzer \
     --verbose \
     --enable-safety-system \
     --spec-schema-version "$SCHEMA_VERSION" \
+    "$@" \
     --output-dir "$FUZZ_OUTPUT_DIR"
 
 FUZZ_EXIT_CODE=$?

--- a/tests/e2e/test_everything_server_docker.sh
+++ b/tests/e2e/test_everything_server_docker.sh
@@ -33,6 +33,6 @@ docker run --rm \
     -e MCP_FUZZER_IN_DOCKER=1 \
     -e "MCP_SPEC_SCHEMA_VERSION=$SCHEMA_VERSION" \
     "$IMAGE_NAME" \
-    bash -lc "./tests/e2e/test_everything_server.sh"
+    bash ./tests/e2e/test_everything_server.sh "$@"
 
 echo -e "${GREEN}✅ Docker e2e test completed${NC}"

--- a/tests/unit/safety_system/test_policy.py
+++ b/tests/unit/safety_system/test_policy.py
@@ -16,9 +16,12 @@ from mcp_fuzzer.safety_system.policy import (
     ("value", "expected"),
     [
         ("https://Example.COM/path", "example.com"),
+        ("http://Example.COM/path", "example.com"),
         ("EXAMPLE.com", "example.com"),
         ("example.com:443", "example.com"),
+        ("::1", "::1"),
         ("[2001:db8::1]:8443", "2001:db8::1"),
+        ("[::1", "::1"),
         ("localhost.", "localhost"),
         ("  localhost  ", "localhost"),
         ("", ""),
@@ -50,6 +53,14 @@ def test_is_host_allowed_trailing_dot_variants():
     assert is_host_allowed(
         "http://localhost",
         allowed_hosts=["localhost."],
+        deny_network_by_default=True,
+    )
+
+
+def test_is_host_allowed_bare_ipv6_loopback():
+    assert is_host_allowed(
+        "::1",
+        allowed_hosts=["::1"],
         deny_network_by_default=True,
     )
 

--- a/tests/unit/safety_system/test_policy.py
+++ b/tests/unit/safety_system/test_policy.py
@@ -1,13 +1,33 @@
 #!/usr/bin/env python3
 import os
+import pytest
 
 from mcp_fuzzer.safety_system.policy import (
+    _normalize_host,
     is_host_allowed,
     resolve_redirect_safely,
     sanitize_subprocess_env,
     sanitize_headers,
     configure_network_policy,
 )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("https://Example.COM/path", "example.com"),
+        ("EXAMPLE.com", "example.com"),
+        ("example.com:443", "example.com"),
+        ("[2001:db8::1]:8443", "2001:db8::1"),
+        ("localhost.", "localhost"),
+        ("  localhost  ", "localhost"),
+        ("", ""),
+        ("   ", ""),
+        (None, ""),
+    ],
+)
+def test_normalize_host_variants(value, expected):
+    assert _normalize_host(value) == expected
 
 
 def test_is_host_allowed_defaults():
@@ -19,6 +39,19 @@ def test_is_host_allowed_defaults():
 def test_is_host_allowed_strict_mode_local_only():
     assert is_host_allowed("http://example.com", deny_network_by_default=True) is False
     assert is_host_allowed("http://localhost", deny_network_by_default=True) is True
+
+
+def test_is_host_allowed_trailing_dot_variants():
+    assert is_host_allowed(
+        "http://localhost.",
+        allowed_hosts=["localhost"],
+        deny_network_by_default=True,
+    )
+    assert is_host_allowed(
+        "http://localhost",
+        allowed_hosts=["localhost."],
+        deny_network_by_default=True,
+    )
 
 
 def test_resolve_redirect_safely_same_origin():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Pull Request Summary: Documentation Alignment with Current Code

## Overview
This is a documentation-only PR that updates many docs to align with the current implementation: it clarifies safety semantics (flag-driven system-level controls), adds protocol-phase and stateful fuzzing knobs, documents StreamableHTTP transport and session-id–based reporting, and reorganizes architecture and component descriptions.

## Key design changes reflected in docs
- Safety model: shift from claim of built-in argument filtering to opt-in system-level controls (command blocking, optional filesystem sandbox via --fs-root, network policy via --no-network / --allow-host) and “argument-level safety hooks” enabled by default but not blocking.
- CLI/config additions: new flags and env vars for protocol fuzzing phases (--protocol-phase), stateful runs (--stateful, --stateful-runs), corpus/havoc toggles, and spec-schema override.
- Transports: StreamableHTTP documented as a supported transport.
- Reporting: session-id (UUID) based reports under reports/sessions/{session_id}, OutputManager and FormatterRegistry responsibilities clarified.
- Architecture/docs refactor: client runner unified; mutators (ToolMutator/ProtocolMutator) and OutputManager added; safety responsibilities moved toward system boundaries and DangerDetector helpers.

## Confirmations from code (sanity checks)
- Large client classes exist:
  - mcp_fuzzer/client/protocol_client.py — 945 lines
  - mcp_fuzzer/client/tool_client.py — 547 lines
  - mcp_fuzzer/client/base.py (MCPFuzzerClient) — 288 lines
- process_supervisor.py — 142 lines; shows duplicate restart_count field definition (two restart_count declarations).
- safety policy implementation present at mcp_fuzzer/safety_system/policy.py with _normalize_host, configure_network_policy, is_host_allowed and tests added in tests/unit/safety_system/test_policy.py validating normalization and policy behavior.

## Design patterns used / introduced
- Command pattern for run planning (RunCommand variants) — documented and present.
- Protocols (typing.Protocol) for safety, provider, and adapter abstractions enabling pluggable components.
- Builder/factory helpers for driver/auth construction (build_driver_with_auth).
- Transport mixins / composition to share HTTP behavior across drivers.
- OutputManager / FormatterRegistry mediating reporting output formats.

## SOLID and design-smell assessment (based on codebase signals & docs)
- Single Responsibility Principle (S): Violations indicated by very large classes:
  - ProtocolClient (~945 LOC) and ToolClient (~547 LOC) combine fuzzing orchestration, mutation, execution, and result handling—hard to test and maintain.
  - MCPFuzzerClient (~288 LOC) mixes coordination and construction responsibilities.
- Open/Closed Principle (O): Extensibility requires modifying central classes (ProtocolClient) rather than plugin extension points in some areas.
- Dependency Inversion (D): Some core behaviors (SafetyFilter, AuthManager) appear created inline in multiple places (scattered instantiation pattern called out in docs), suggesting weaker inversion and missed DI opportunities.
- Liskov Substitution (L) & Interface Contracts: Use of dynamic/magic config access (ClientSettings __getattr__/dict-backed access) risks implicit contracts and substitutability issues.
- Other smells:
  - Duplicate field in transport/controller/process_supervisor.py: restart_count declared twice — copy/paste/refactor residue (critical fix).
  - Large classes: make unit testing and SRP adherence difficult.
  - Scattered instance creation: SafetyFilter and similar objects instantiated in several locations rather than via a central factory/DI container.
  - Fragile argv reconstruction and reflective helpers (noted in prior review) remain a maintenance risk.
  - Mutable settings dataclass used where an immutable config object would be safer.

## Documentation-code alignment notes / inconsistencies
- Docs correctly document that network deny is opt-in (SAFETY_NO_NETWORK_DEFAULT=False) and that safety system behaviors are flag-driven — code and tests reflect this.
- The docs shift from "argument filtering blocks by default" to "hooks by default, system controls opt-in" matches policy.py behavior and tests.
- Network host normalization and trailing-dot handling in policy.py matches tests added; docs and code use the new normalization semantics.
- The PR is documentation-only; no public API or exported symbol changes detected in the diffs.

## Recommended follow-ups (prioritized)
1. Remove duplicate restart_count field in transport/controller/process_supervisor.py.
2. Centralize SafetyFilter / safety provider construction (factory or DI) to avoid scattered instantiation and improve testability.
3. Break up very large client classes (ProtocolClient, ToolClient) into smaller responsibilities (orchestrator, executor, result aggregator).
4. Introduce clearer extension/plugin points for new protocol types (registry/factory) to honor Open/Closed.
5. Replace magic/dynamic config access with an explicit, (preferably immutable) config object to solidify contracts.
6. Add a short doc section describing internal coupling (where SafetyFilter/enable flags are created) and recommended extension points so docs reflect technical debt and extension guidance.

## Conclusion
The documentation changes accurately reflect the code's current behaviors and new CLI/config surface area. They also intentionally reframe safety as flag-driven system protections and clarify reporting/transport changes. The codebase still exhibits design smells (oversized classes, duplicated fields, scattered construction of core services) that are not addressed by this PR — the docs now surface some of these choices but further refactoring is recommended to improve SOLID compliance and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->