### PR TITLE
Refine reporting boundaries and result contracts

### DIFF
--- a/mcp_fuzzer/client/base.py
+++ b/mcp_fuzzer/client/base.py
@@ -123,16 +123,21 @@ class MCPFuzzerClient:
             tool_timeout=effective_timeout,
         )
 
-    async def fuzz_tool_both_phases(self, tool, runs_per_phase=5):
+    async def fuzz_tool_both_phases(self, tool, runs_per_phase=5, tool_timeout=None):
         """Fuzz a tool in both realistic and aggressive phases."""
+        effective_timeout = self._resolve_tool_timeout(tool_timeout)
         return await self.tool_client.fuzz_tool_both_phases(
-            tool, runs_per_phase=runs_per_phase
+            tool,
+            runs_per_phase=runs_per_phase,
+            tool_timeout=effective_timeout,
         )
 
-    async def fuzz_all_tools_both_phases(self, runs_per_phase=5):
+    async def fuzz_all_tools_both_phases(self, runs_per_phase=5, tool_timeout=None):
         """Fuzz all tools in both realistic and aggressive phases."""
+        effective_timeout = self._resolve_tool_timeout(tool_timeout)
         return await self.tool_client.fuzz_all_tools_both_phases(
-            runs_per_phase=runs_per_phase
+            runs_per_phase=runs_per_phase,
+            tool_timeout=effective_timeout,
         )
 
     # ============================================================================

--- a/mcp_fuzzer/client/base.py
+++ b/mcp_fuzzer/client/base.py
@@ -12,6 +12,7 @@ from typing import Any
 from ..auth import AuthManager
 from ..reports import FuzzerReporter
 from ..safety_system.safety import CombinedSafetyProvider, SafetyFilter
+from ..types import AuthManagerProtocol, ProtocolFuzzResult, ToolRunResult
 
 from .tool_client import ToolClient
 from .protocol_client import ProtocolClient
@@ -29,7 +30,7 @@ class MCPFuzzerClient:
     def __init__(
         self,
         transport,
-        auth_manager: AuthManager | None = None,
+        auth_manager: AuthManagerProtocol | None = None,
         tool_timeout: float | None = None,
         reporter: FuzzerReporter | None = None,
         safety_system: CombinedSafetyProvider | None = None,
@@ -96,8 +97,8 @@ class MCPFuzzerClient:
 
     async def _fuzz_protocol_group(
         self, protocol_types: tuple[str, ...], runs_per_type: int, phase: str
-    ) -> dict[str, list[dict[str, Any]]]:
-        results: dict[str, list[dict[str, Any]]] = {}
+    ) -> dict[str, list[ProtocolFuzzResult]]:
+        results: dict[str, list[ProtocolFuzzResult]] = {}
         for protocol_type in protocol_types:
             results[protocol_type] = await self.protocol_client.fuzz_protocol_type(
                 protocol_type, runs=runs_per_type, phase=phase
@@ -108,14 +109,23 @@ class MCPFuzzerClient:
     # Tool Fuzzing Methods - Delegate to ToolClient
     # ============================================================================
 
-    async def fuzz_tool(self, tool, runs=10, tool_timeout=None):
+    async def fuzz_tool(
+        self,
+        tool: dict[str, Any],
+        runs: int = 10,
+        tool_timeout: float | None = None,
+    ) -> list[ToolRunResult]:
         """Fuzz a specific tool."""
         effective_timeout = self._resolve_tool_timeout(tool_timeout)
         return await self.tool_client.fuzz_tool(
             tool, runs=runs, tool_timeout=effective_timeout
         )
 
-    async def fuzz_all_tools(self, runs_per_tool=10, tool_timeout=None):
+    async def fuzz_all_tools(
+        self,
+        runs_per_tool: int = 10,
+        tool_timeout: float | None = None,
+    ):
         """Fuzz all available tools."""
         effective_timeout = self._resolve_tool_timeout(tool_timeout)
         return await self.tool_client.fuzz_all_tools(
@@ -123,7 +133,12 @@ class MCPFuzzerClient:
             tool_timeout=effective_timeout,
         )
 
-    async def fuzz_tool_both_phases(self, tool, runs_per_phase=5, tool_timeout=None):
+    async def fuzz_tool_both_phases(
+        self,
+        tool: dict[str, Any],
+        runs_per_phase: int = 5,
+        tool_timeout: float | None = None,
+    ):
         """Fuzz a tool in both realistic and aggressive phases."""
         effective_timeout = self._resolve_tool_timeout(tool_timeout)
         return await self.tool_client.fuzz_tool_both_phases(
@@ -132,7 +147,11 @@ class MCPFuzzerClient:
             tool_timeout=effective_timeout,
         )
 
-    async def fuzz_all_tools_both_phases(self, runs_per_phase=5, tool_timeout=None):
+    async def fuzz_all_tools_both_phases(
+        self,
+        runs_per_phase: int = 5,
+        tool_timeout: float | None = None,
+    ):
         """Fuzz all tools in both realistic and aggressive phases."""
         effective_timeout = self._resolve_tool_timeout(tool_timeout)
         return await self.tool_client.fuzz_all_tools_both_phases(
@@ -144,7 +163,12 @@ class MCPFuzzerClient:
     # Protocol Fuzzing Methods - Delegate to ProtocolClient
     # ============================================================================
 
-    async def fuzz_protocol_type(self, protocol_type, runs=10, phase=None):
+    async def fuzz_protocol_type(
+        self,
+        protocol_type: str,
+        runs: int = 10,
+        phase: str | None = None,
+    ) -> list[ProtocolFuzzResult]:
         """Fuzz a specific protocol type."""
         if phase is None:
             return await self.protocol_client.fuzz_protocol_type(
@@ -154,7 +178,11 @@ class MCPFuzzerClient:
             protocol_type, runs=runs, phase=phase
         )
 
-    async def fuzz_all_protocol_types(self, runs_per_type=5, phase=None):
+    async def fuzz_all_protocol_types(
+        self,
+        runs_per_type: int = 5,
+        phase: str | None = None,
+    ) -> dict[str, list[ProtocolFuzzResult]]:
         """Fuzz all protocol types."""
         if phase is None:
             return await self.protocol_client.fuzz_all_protocol_types(

--- a/mcp_fuzzer/client/main.py
+++ b/mcp_fuzzer/client/main.py
@@ -168,10 +168,7 @@ async def unified_client_main(settings: ClientSettings) -> int:
                 include_safety=config.get("safety_report", False),
             )
             if exported_files:
-                logging.info(
-                    "Exported report formats: %s",
-                    {name: path for name, path in exported_files.items()},
-                )
+                logging.info("Exported report formats: %s", exported_files)
 
         except Exception as exc:  # pragma: no cover
             logging.warning(f"Failed to export additional report formats: {exc}")

--- a/mcp_fuzzer/client/main.py
+++ b/mcp_fuzzer/client/main.py
@@ -5,18 +5,55 @@ from __future__ import annotations
 
 import logging
 import os
-
-from ..utils.icons import ALERT, CHECK, ROCKET, STATS, TARGET
+from typing import Any
 
 from ..reports import FuzzerReporter
-from ..reports.formatters.common import extract_tool_runs
 from ..safety_system.safety import SafetyFilter
 from ..exceptions import MCPError
 from ..corpus import build_corpus_root, build_target_id, default_fs_root
 from .settings import ClientSettings
 from .base import MCPFuzzerClient
-from .transport import build_driver_with_auth
+from .transport import TransportBuildRequest, build_driver_with_auth
 from .runtime import RunContext, build_run_plan
+
+
+def _build_transport_request(config: dict[str, Any]) -> TransportBuildRequest:
+    return TransportBuildRequest(
+        protocol=config["protocol"],
+        endpoint=config["endpoint"],
+        timeout=config.get("timeout", 30.0),
+        transport_retries=config.get("transport_retries", 1),
+        transport_retry_delay=config.get("transport_retry_delay", 0.5),
+        transport_retry_backoff=config.get("transport_retry_backoff", 2.0),
+        transport_retry_max_delay=config.get("transport_retry_max_delay", 5.0),
+        transport_retry_jitter=config.get("transport_retry_jitter", 0.1),
+        auth_manager=config.get("auth_manager"),
+        safety_enabled=config.get("safety_enabled", True),
+    )
+
+
+def _requested_export_targets(config: dict[str, Any]) -> dict[str, str]:
+    export_targets: dict[str, str] = {}
+    for config_key, format_name in (
+        ("export_csv", "csv"),
+        ("export_xml", "xml"),
+        ("export_html", "html"),
+        ("export_markdown", "markdown"),
+    ):
+        filename = config.get(config_key)
+        if filename:
+            export_targets[format_name] = filename
+    return export_targets
+
+
+def _set_report_metadata(reporter: FuzzerReporter, config: dict[str, Any]) -> None:
+    reporter.set_fuzzing_metadata(
+        mode=config.get("mode", "unknown"),
+        protocol=config.get("protocol", "unknown"),
+        endpoint=config.get("endpoint", "unknown"),
+        runs=config.get("runs", 0),
+        runs_per_type=config.get("runs_per_type"),
+    )
 
 
 async def unified_client_main(settings: ClientSettings) -> int:
@@ -35,43 +72,7 @@ async def unified_client_main(settings: ClientSettings) -> int:
         f"md={config.get('export_markdown', False)}"
     )
 
-    class Args:
-        def __init__(
-            self,
-            protocol,
-            endpoint,
-            timeout,
-            transport_retries,
-            transport_retry_delay,
-            transport_retry_backoff,
-            transport_retry_max_delay,
-            transport_retry_jitter,
-        ):
-            self.protocol = protocol
-            self.endpoint = endpoint
-            self.timeout = timeout
-            self.transport_retries = transport_retries
-            self.transport_retry_delay = transport_retry_delay
-            self.transport_retry_backoff = transport_retry_backoff
-            self.transport_retry_max_delay = transport_retry_max_delay
-            self.transport_retry_jitter = transport_retry_jitter
-
-    args = Args(
-        protocol=config["protocol"],
-        endpoint=config["endpoint"],
-        timeout=config.get("timeout", 30.0),
-        transport_retries=config.get("transport_retries", 1),
-        transport_retry_delay=config.get("transport_retry_delay", 0.5),
-        transport_retry_backoff=config.get("transport_retry_backoff", 2.0),
-        transport_retry_max_delay=config.get("transport_retry_max_delay", 5.0),
-        transport_retry_jitter=config.get("transport_retry_jitter", 0.1),
-    )  # pragma: no cover
-
-    client_args = {
-        "auth_manager": config.get("auth_manager"),
-    }
-
-    transport = build_driver_with_auth(args, client_args)
+    transport = build_driver_with_auth(_build_transport_request(config))
 
     safety_enabled = config.get("safety_enabled", True)
     safety_system = None
@@ -109,6 +110,8 @@ async def unified_client_main(settings: ClientSettings) -> int:
         corpus_root=corpus_root,
         havoc_mode=config.get("havoc_mode", False),
     )
+    reporter = client.reporter
+    _set_report_metadata(reporter, config)
 
     try:
         mode = config["mode"]
@@ -134,69 +137,20 @@ async def unified_client_main(settings: ClientSettings) -> int:
                 and isinstance(tool_results, dict)
                 and tool_results
             ):
-                print("\n" + "=" * 80)
-                print(f"{TARGET} MCP FUZZER TOOL RESULTS SUMMARY")
-                print("=" * 80)
-                client.print_tool_summary(tool_results)
-
-                total_tools = len(tool_results)
-                total_runs = sum(
-                    len(extract_tool_runs(runs)[0]) for runs in tool_results.values()
-                )
-                total_exceptions = sum(
-                    len([r for r in extract_tool_runs(runs)[0] if r.get("exception")])
-                    for runs in tool_results.values()
-                )
-
-                success_rate = (
-                    ((total_runs - total_exceptions) / total_runs * 100)
-                    if total_runs > 0
-                    else 0
-                )
-
-                print(f"\n{STATS} OVERALL STATISTICS")
-                print("-" * 40)
-                print(f"• Total Tools Tested: {total_tools}")
-                print(f"• Total Fuzzing Runs: {total_runs}")
-                print(f"• Total Exceptions: {total_exceptions}")
-                print(f"• Overall Success Rate: {success_rate:.1f}%")
-
-                vulnerable_tools = []
-                for tool_name, runs in tool_results.items():
-                    run_entries = extract_tool_runs(runs)[0]
-                    exceptions = len([r for r in run_entries if r.get("exception")])
-                    if exceptions > 0:
-                        vulnerable_tools.append(
-                            (tool_name, exceptions, len(run_entries))
-                        )
-
-                if vulnerable_tools:
-                    print(
-                        f"\n{ALERT} VULNERABILITIES FOUND: {len(vulnerable_tools)}"
-                    )
-                    for tool, exceptions, total in vulnerable_tools:
-                        rate = exceptions / total * 100
-                        print(
-                            f"  • {tool}: {exceptions}/{total} exceptions ({rate:.1f}%)"
-                        )
-                else:
-                    print(f"\n{CHECK} NO VULNERABILITIES FOUND")
+                reporter.print_tool_execution_summary(tool_results)
 
         except Exception as exc:  # pragma: no cover
             logging.warning(f"Failed to display table summary: {exc}")
 
         try:  # pragma: no cover
             if isinstance(protocol_results, dict) and protocol_results:
-                print("\n" + "=" * 80)
-                print(f"{ROCKET} MCP FUZZER PROTOCOL RESULTS SUMMARY")
-                print("=" * 80)
-                client.print_protocol_summary(protocol_results)
+                reporter.print_protocol_summary(protocol_results)
         except Exception as exc:  # pragma: no cover
             logging.warning(f"Failed to display protocol summary tables: {exc}")
 
         try:  # pragma: no cover
             output_types = config.get("output_types")
-            standardized_files = await client.generate_standardized_reports(
+            standardized_files = await reporter.generate_standardized_report(
                 output_types=output_types,
                 include_safety=config.get("safety_report", False),
             )
@@ -208,46 +162,16 @@ async def unified_client_main(settings: ClientSettings) -> int:
             logging.warning(f"Failed to generate standardized reports: {exc}")
 
         try:  # pragma: no cover
-            logging.info(
-                "Checking export flags: "
-                f"csv={config.get('export_csv', False)}, "
-                f"xml={config.get('export_xml', False)}, "
-                f"html={config.get('export_html', False)}, "
-                f"md={config.get('export_markdown', False)}"
+            export_targets = _requested_export_targets(config)
+            exported_files = await reporter.export_requested_formats(
+                export_targets,
+                include_safety=config.get("safety_report", False),
             )
-            logging.info(f"Client reporter available: {client.reporter is not None}")
-
-            if config.get("export_csv"):
-                csv_filename = config["export_csv"]
-                if client.reporter:
-                    await client.reporter.export_format("csv", csv_filename)
-                    logging.info(f"Exported CSV report to: {csv_filename}")
-                else:
-                    logging.warning("No reporter available for CSV export")
-
-            if config.get("export_xml"):
-                xml_filename = config["export_xml"]
-                if client.reporter:
-                    await client.reporter.export_format("xml", xml_filename)
-                    logging.info(f"Exported XML report to: {xml_filename}")
-                else:
-                    logging.warning("No reporter available for XML export")
-
-            if config.get("export_html"):
-                html_filename = config["export_html"]
-                if client.reporter:
-                    await client.reporter.export_format("html", html_filename)
-                    logging.info(f"Exported HTML report to: {html_filename}")
-                else:
-                    logging.warning("No reporter available for HTML export")
-
-            if config.get("export_markdown"):
-                markdown_filename = config["export_markdown"]
-                if client.reporter:
-                    await client.reporter.export_format("markdown", markdown_filename)
-                    logging.info(f"Exported Markdown report to: {markdown_filename}")
-                else:
-                    logging.warning("No reporter available for Markdown export")
+            if exported_files:
+                logging.info(
+                    "Exported report formats: %s",
+                    {name: path for name, path in exported_files.items()},
+                )
 
         except Exception as exc:  # pragma: no cover
             logging.warning(f"Failed to export additional report formats: {exc}")

--- a/mcp_fuzzer/client/protocol_client.py
+++ b/mcp_fuzzer/client/protocol_client.py
@@ -6,7 +6,6 @@ This module provides functionality for fuzzing MCP protocol types.
 """
 
 import copy
-import inspect
 import json
 import logging
 import random
@@ -14,7 +13,7 @@ import traceback
 from pathlib import Path
 from typing import Any
 
-from ..types import ProtocolFuzzResult, SafetyCheckResult, PREVIEW_LENGTH
+from ..types import PREVIEW_LENGTH, ProtocolFuzzResult, ProtocolSpec, SafetyCheckResult
 from ..protocol_types import GET_PROMPT_REQUEST, READ_RESOURCE_REQUEST
 from ..protocol_registry import EXECUTABLE_PROTOCOL_TYPES
 from ..utils.schema_helpers import _build_tool_arguments, _tool_task_support
@@ -27,123 +26,100 @@ from ..safety_system.safety import CombinedSafetyProvider, ProtocolSafetyProvide
 # ProtocolClient owns the executable protocol list it can iterate over.
 SUPPORTED_PROTOCOL_TYPES = tuple(EXECUTABLE_PROTOCOL_TYPES)
 
-_PROTOCOL_SPECS: dict[str, dict[str, Any]] = {
-    "InitializeRequest": {
-        "handler_name": "_send_initialize_request",
-        "method": "initialize",
-        "is_notification": False,
-    },
-    "InitializedNotification": {
-        "handler_name": "_send_initialized_notification",
-        "method": "notifications/initialized",
-        "is_notification": True,
-    },
-    "ProgressNotification": {
-        "handler_name": "_send_progress_notification",
-        "method": "notifications/progress",
-        "is_notification": True,
-    },
-    "CancelledNotification": {
-        "handler_name": "_send_cancelled_notification",
-        "method": "notifications/cancelled",
-        "is_notification": True,
-    },
-    "ListToolsRequest": {
-        "handler_name": "_send_list_tools_request",
-        "method": "tools/list",
-        "is_notification": False,
-    },
-    "CallToolRequest": {
-        "handler_name": "_send_call_tool_request",
-        "method": "tools/call",
-        "is_notification": False,
-    },
-    "ListResourcesRequest": {
-        "handler_name": "_send_list_resources_request",
-        "method": "resources/list",
-        "is_notification": False,
-    },
-    READ_RESOURCE_REQUEST: {
-        "handler_name": "_send_read_resource_request",
-        "method": "resources/read",
-        "is_notification": False,
-    },
-    "ListResourceTemplatesRequest": {
-        "handler_name": "_send_list_resource_templates_request",
-        "method": "resources/templates/list",
-        "is_notification": False,
-    },
-    "SetLevelRequest": {
-        "handler_name": "_send_set_level_request",
-        "method": "logging/setLevel",
-        "is_notification": False,
-    },
-    "CreateMessageRequest": {
-        "handler_name": "_send_create_message_request",
-        "method": "sampling/createMessage",
-        "is_notification": False,
-    },
-    "ListPromptsRequest": {
-        "handler_name": "_send_list_prompts_request",
-        "method": "prompts/list",
-        "is_notification": False,
-    },
-    GET_PROMPT_REQUEST: {
-        "handler_name": "_send_get_prompt_request",
-        "method": "prompts/get",
-        "is_notification": False,
-    },
-    "ListRootsRequest": {
-        "handler_name": "_send_list_roots_request",
-        "method": "roots/list",
-        "is_notification": False,
-    },
-    "SubscribeRequest": {
-        "handler_name": "_send_subscribe_request",
-        "method": "resources/subscribe",
-        "is_notification": False,
-    },
-    "UnsubscribeRequest": {
-        "handler_name": "_send_unsubscribe_request",
-        "method": "resources/unsubscribe",
-        "is_notification": False,
-    },
-    "CompleteRequest": {
-        "handler_name": "_send_complete_request",
-        "method": "completion/complete",
-        "is_notification": False,
-    },
-    "ElicitRequest": {
-        "handler_name": "_send_elicit_request",
-        "method": "elicitation/create",
-        "is_notification": False,
-    },
-    "ListTasksRequest": {
-        "handler_name": "_send_list_tasks_request",
-        "method": "tasks/list",
-        "is_notification": False,
-    },
-    "GetTaskRequest": {
-        "handler_name": "_send_get_task_request",
-        "method": "tasks/get",
-        "is_notification": False,
-    },
-    "GetTaskPayloadRequest": {
-        "handler_name": "_send_get_task_payload_request",
-        "method": "tasks/result",
-        "is_notification": False,
-    },
-    "CancelTaskRequest": {
-        "handler_name": "_send_cancel_task_request",
-        "method": "tasks/cancel",
-        "is_notification": False,
-    },
-    "PingRequest": {
-        "handler_name": "_send_ping_request",
-        "method": "ping",
-        "is_notification": False,
-    },
+_PROTOCOL_SPECS: dict[str, ProtocolSpec] = {
+    "InitializeRequest": ProtocolSpec("_send_initialize_request", "initialize", False),
+    "InitializedNotification": ProtocolSpec(
+        "_send_initialized_notification",
+        "notifications/initialized",
+        True,
+    ),
+    "ProgressNotification": ProtocolSpec(
+        "_send_progress_notification",
+        "notifications/progress",
+        True,
+    ),
+    "CancelledNotification": ProtocolSpec(
+        "_send_cancelled_notification",
+        "notifications/cancelled",
+        True,
+    ),
+    "ListToolsRequest": ProtocolSpec("_send_list_tools_request", "tools/list", False),
+    "CallToolRequest": ProtocolSpec("_send_call_tool_request", "tools/call", False),
+    "ListResourcesRequest": ProtocolSpec(
+        "_send_list_resources_request",
+        "resources/list",
+        False,
+    ),
+    READ_RESOURCE_REQUEST: ProtocolSpec(
+        "_send_read_resource_request",
+        "resources/read",
+        False,
+    ),
+    "ListResourceTemplatesRequest": ProtocolSpec(
+        "_send_list_resource_templates_request",
+        "resources/templates/list",
+        False,
+    ),
+    "SetLevelRequest": ProtocolSpec(
+        "_send_set_level_request",
+        "logging/setLevel",
+        False,
+    ),
+    "CreateMessageRequest": ProtocolSpec(
+        "_send_create_message_request",
+        "sampling/createMessage",
+        False,
+    ),
+    "ListPromptsRequest": ProtocolSpec(
+        "_send_list_prompts_request",
+        "prompts/list",
+        False,
+    ),
+    GET_PROMPT_REQUEST: ProtocolSpec("_send_get_prompt_request", "prompts/get", False),
+    "ListRootsRequest": ProtocolSpec("_send_list_roots_request", "roots/list", False),
+    "SubscribeRequest": ProtocolSpec(
+        "_send_subscribe_request",
+        "resources/subscribe",
+        False,
+    ),
+    "UnsubscribeRequest": ProtocolSpec(
+        "_send_unsubscribe_request",
+        "resources/unsubscribe",
+        False,
+    ),
+    "CompleteRequest": ProtocolSpec(
+        "_send_complete_request",
+        "completion/complete",
+        False,
+    ),
+    "ElicitRequest": ProtocolSpec(
+        "_send_elicit_request",
+        "elicitation/create",
+        False,
+    ),
+    "ListTasksRequest": ProtocolSpec("_send_list_tasks_request", "tasks/list", False),
+    "GetTaskRequest": ProtocolSpec("_send_get_task_request", "tasks/get", False),
+    "GetTaskPayloadRequest": ProtocolSpec(
+        "_send_get_task_payload_request",
+        "tasks/result",
+        False,
+    ),
+    "CancelTaskRequest": ProtocolSpec(
+        "_send_cancel_task_request",
+        "tasks/cancel",
+        False,
+    ),
+    "PingRequest": ProtocolSpec("_send_ping_request", "ping", False),
 }
+
+
+def _validate_protocol_specs() -> None:
+    for protocol_type, spec in _PROTOCOL_SPECS.items():
+        if not spec.handler_name or not spec.method:
+            raise ValueError(f"Invalid protocol spec for {protocol_type!r}")
+
+
+_validate_protocol_specs()
 
 
 class ProtocolClient:
@@ -570,8 +546,6 @@ class ProtocolClient:
         """Fuzz all protocol types using ProtocolClient safety + sending."""
         try:
             protocol_types = self._get_protocol_types()
-            if inspect.isawaitable(protocol_types):
-                protocol_types = await protocol_types
             if not protocol_types:
                 self._logger.warning("No protocol types available")
                 return {}
@@ -896,7 +870,7 @@ class ProtocolClient:
         """Send a protocol request based on the type."""
         spec = _PROTOCOL_SPECS.get(protocol_type)
         handler_name = (
-            spec["handler_name"] if spec is not None else "_send_generic_request"
+            spec.handler_name if spec is not None else "_send_generic_request"
         )
         handler = getattr(self, handler_name)
         return await handler(data)
@@ -1002,8 +976,8 @@ class ProtocolClient:
         self, protocol_type: str, data: Any
     ) -> dict[str, Any] | dict[str, str]:
         spec = _PROTOCOL_SPECS[protocol_type]
-        method = spec["method"]
-        if spec["is_notification"]:
+        method = spec.method
+        if spec.is_notification:
             return await self._send_notification(method, data)
         return await self._send_request(method, data)
 

--- a/mcp_fuzzer/client/protocol_client.py
+++ b/mcp_fuzzer/client/protocol_client.py
@@ -6,6 +6,7 @@ This module provides functionality for fuzzing MCP protocol types.
 """
 
 import copy
+import inspect
 import json
 import logging
 import random
@@ -555,7 +556,7 @@ class ProtocolClient:
         await self._append_follow_up_results(results, protocol_type)
         return results
 
-    async def _get_protocol_types(self) -> list[str]:
+    def _get_protocol_types(self) -> list[str]:
         """Get list of protocol types to fuzz.
 
         Returns:
@@ -568,7 +569,9 @@ class ProtocolClient:
     ) -> dict[str, list[ProtocolFuzzResult]]:
         """Fuzz all protocol types using ProtocolClient safety + sending."""
         try:
-            protocol_types = await self._get_protocol_types()
+            protocol_types = self._get_protocol_types()
+            if inspect.isawaitable(protocol_types):
+                protocol_types = await protocol_types
             if not protocol_types:
                 self._logger.warning("No protocol types available")
                 return {}

--- a/mcp_fuzzer/client/protocol_client.py
+++ b/mcp_fuzzer/client/protocol_client.py
@@ -26,6 +26,124 @@ from ..safety_system.safety import CombinedSafetyProvider, ProtocolSafetyProvide
 # ProtocolClient owns the executable protocol list it can iterate over.
 SUPPORTED_PROTOCOL_TYPES = tuple(EXECUTABLE_PROTOCOL_TYPES)
 
+_PROTOCOL_SPECS: dict[str, dict[str, Any]] = {
+    "InitializeRequest": {
+        "handler_name": "_send_initialize_request",
+        "method": "initialize",
+        "is_notification": False,
+    },
+    "InitializedNotification": {
+        "handler_name": "_send_initialized_notification",
+        "method": "notifications/initialized",
+        "is_notification": True,
+    },
+    "ProgressNotification": {
+        "handler_name": "_send_progress_notification",
+        "method": "notifications/progress",
+        "is_notification": True,
+    },
+    "CancelledNotification": {
+        "handler_name": "_send_cancelled_notification",
+        "method": "notifications/cancelled",
+        "is_notification": True,
+    },
+    "ListToolsRequest": {
+        "handler_name": "_send_list_tools_request",
+        "method": "tools/list",
+        "is_notification": False,
+    },
+    "CallToolRequest": {
+        "handler_name": "_send_call_tool_request",
+        "method": "tools/call",
+        "is_notification": False,
+    },
+    "ListResourcesRequest": {
+        "handler_name": "_send_list_resources_request",
+        "method": "resources/list",
+        "is_notification": False,
+    },
+    READ_RESOURCE_REQUEST: {
+        "handler_name": "_send_read_resource_request",
+        "method": "resources/read",
+        "is_notification": False,
+    },
+    "ListResourceTemplatesRequest": {
+        "handler_name": "_send_list_resource_templates_request",
+        "method": "resources/templates/list",
+        "is_notification": False,
+    },
+    "SetLevelRequest": {
+        "handler_name": "_send_set_level_request",
+        "method": "logging/setLevel",
+        "is_notification": False,
+    },
+    "CreateMessageRequest": {
+        "handler_name": "_send_create_message_request",
+        "method": "sampling/createMessage",
+        "is_notification": False,
+    },
+    "ListPromptsRequest": {
+        "handler_name": "_send_list_prompts_request",
+        "method": "prompts/list",
+        "is_notification": False,
+    },
+    GET_PROMPT_REQUEST: {
+        "handler_name": "_send_get_prompt_request",
+        "method": "prompts/get",
+        "is_notification": False,
+    },
+    "ListRootsRequest": {
+        "handler_name": "_send_list_roots_request",
+        "method": "roots/list",
+        "is_notification": False,
+    },
+    "SubscribeRequest": {
+        "handler_name": "_send_subscribe_request",
+        "method": "resources/subscribe",
+        "is_notification": False,
+    },
+    "UnsubscribeRequest": {
+        "handler_name": "_send_unsubscribe_request",
+        "method": "resources/unsubscribe",
+        "is_notification": False,
+    },
+    "CompleteRequest": {
+        "handler_name": "_send_complete_request",
+        "method": "completion/complete",
+        "is_notification": False,
+    },
+    "ElicitRequest": {
+        "handler_name": "_send_elicit_request",
+        "method": "elicitation/create",
+        "is_notification": False,
+    },
+    "ListTasksRequest": {
+        "handler_name": "_send_list_tasks_request",
+        "method": "tasks/list",
+        "is_notification": False,
+    },
+    "GetTaskRequest": {
+        "handler_name": "_send_get_task_request",
+        "method": "tasks/get",
+        "is_notification": False,
+    },
+    "GetTaskPayloadRequest": {
+        "handler_name": "_send_get_task_payload_request",
+        "method": "tasks/result",
+        "is_notification": False,
+    },
+    "CancelTaskRequest": {
+        "handler_name": "_send_cancel_task_request",
+        "method": "tasks/cancel",
+        "is_notification": False,
+    },
+    "PingRequest": {
+        "handler_name": "_send_ping_request",
+        "method": "ping",
+        "is_notification": False,
+    },
+}
+
 
 class ProtocolClient:
     """Client for fuzzing MCP protocol types."""
@@ -434,20 +552,7 @@ class ProtocolClient:
             )
             results.append(result)
 
-        if protocol_type == READ_RESOURCE_REQUEST:
-            results.extend(await self._fuzz_listed_resources())
-        elif protocol_type == GET_PROMPT_REQUEST:
-            results.extend(await self._fuzz_listed_prompts())
-        elif protocol_type == "CallToolRequest":
-            results.extend(await self._fuzz_listed_tools())
-        elif protocol_type in {
-            "ListTasksRequest",
-            "GetTaskRequest",
-            "GetTaskPayloadRequest",
-            "CancelTaskRequest",
-        }:
-            results.extend(await self._fuzz_observed_tasks(protocol_type))
-
+        await self._append_follow_up_results(results, protocol_type)
         return results
 
     async def _get_protocol_types(self) -> list[str]:
@@ -477,30 +582,34 @@ class ProtocolClient:
                         )
                     )
                 all_results[pt] = per_type
-            if READ_RESOURCE_REQUEST in all_results:
-                all_results[READ_RESOURCE_REQUEST].extend(
-                    await self._fuzz_listed_resources()
-                )
-            if GET_PROMPT_REQUEST in all_results:
-                all_results[GET_PROMPT_REQUEST].extend(
-                    await self._fuzz_listed_prompts()
-                )
-            if "CallToolRequest" in all_results:
-                all_results["CallToolRequest"].extend(await self._fuzz_listed_tools())
-            for protocol_type in (
-                "ListTasksRequest",
-                "GetTaskRequest",
-                "GetTaskPayloadRequest",
-                "CancelTaskRequest",
-            ):
-                if protocol_type in all_results:
-                    all_results[protocol_type].extend(
-                        await self._fuzz_observed_tasks(protocol_type)
-                    )
+            for protocol_type, results in all_results.items():
+                await self._append_follow_up_results(results, protocol_type)
             return all_results
         except Exception as e:
             self._logger.error(f"Failed to fuzz all protocol types: {e}")
             return {}
+
+    async def _append_follow_up_results(
+        self,
+        results: list[ProtocolFuzzResult],
+        protocol_type: str,
+    ) -> None:
+        if protocol_type == READ_RESOURCE_REQUEST:
+            results.extend(await self._fuzz_listed_resources())
+            return
+        if protocol_type == GET_PROMPT_REQUEST:
+            results.extend(await self._fuzz_listed_prompts())
+            return
+        if protocol_type == "CallToolRequest":
+            results.extend(await self._fuzz_listed_tools())
+            return
+        if protocol_type in {
+            "ListTasksRequest",
+            "GetTaskRequest",
+            "GetTaskPayloadRequest",
+            "CancelTaskRequest",
+        }:
+            results.extend(await self._fuzz_observed_tasks(protocol_type))
 
     def _extract_params(self, data: Any) -> dict[str, Any]:
         """Extract parameters from data, safely handling non-dict inputs.
@@ -589,53 +698,59 @@ class ProtocolClient:
     def _build_tool_arguments(self, tool: dict[str, Any]) -> dict[str, Any]:
         return _build_tool_arguments(tool)
 
-    async def _fetch_listed_resources(self) -> list[dict[str, Any]]:
+    async def _fetch_listed_items(
+        self,
+        *,
+        method: str,
+        key: str,
+        entity_name: str,
+        remember: Any | None = None,
+    ) -> list[dict[str, Any]]:
         try:
-            result = await self.transport.send_request("resources/list", {})
+            result = await self.transport.send_request(method, {})
         except Exception as exc:
-            self._logger.warning("Failed to list resources: %s", exc)
+            self._logger.warning("Failed to list %s: %s", entity_name, exc)
             return []
-        items = self._extract_list_items(result, "resources")
-        return [item for item in items if isinstance(item, dict)]
+
+        items = [
+            item
+            for item in self._extract_list_items(result, key)
+            if isinstance(item, dict)
+        ]
+        if remember is not None:
+            for item in items:
+                remember(item)
+        return items
+
+    async def _fetch_listed_resources(self) -> list[dict[str, Any]]:
+        return await self._fetch_listed_items(
+            method="resources/list",
+            key="resources",
+            entity_name="resources",
+        )
 
     async def _fetch_listed_prompts(self) -> list[dict[str, Any]]:
-        try:
-            result = await self.transport.send_request("prompts/list", {})
-        except Exception as exc:
-            self._logger.warning("Failed to list prompts: %s", exc)
-            return []
-        items = self._extract_list_items(result, "prompts")
-        return [item for item in items if isinstance(item, dict)]
+        return await self._fetch_listed_items(
+            method="prompts/list",
+            key="prompts",
+            entity_name="prompts",
+        )
 
     async def _fetch_listed_tools(self) -> list[dict[str, Any]]:
-        try:
-            result = await self.transport.send_request("tools/list", {})
-        except Exception as exc:
-            self._logger.warning("Failed to list tools: %s", exc)
-            return []
-        items = [
-            item
-            for item in self._extract_list_items(result, "tools")
-            if isinstance(item, dict)
-        ]
-        for tool in items:
-            self._remember_tool(tool)
-        return items
+        return await self._fetch_listed_items(
+            method="tools/list",
+            key="tools",
+            entity_name="tools",
+            remember=self._remember_tool,
+        )
 
     async def _fetch_listed_tasks(self) -> list[dict[str, Any]]:
-        try:
-            result = await self.transport.send_request("tasks/list", {})
-        except Exception as exc:
-            self._logger.warning("Failed to list tasks: %s", exc)
-            return []
-        items = [
-            item
-            for item in self._extract_list_items(result, "tasks")
-            if isinstance(item, dict)
-        ]
-        for task in items:
-            self._remember_task(task)
-        return items
+        return await self._fetch_listed_items(
+            method="tasks/list",
+            key="tasks",
+            entity_name="tasks",
+            remember=self._remember_task,
+        )
 
     async def _process_protocol_request(
         self,
@@ -776,31 +891,11 @@ class ProtocolClient:
         self, protocol_type: str, data: dict[str, Any]
     ) -> dict[str, Any]:
         """Send a protocol request based on the type."""
-        handler = {
-            "InitializeRequest": self._send_initialize_request,
-            "InitializedNotification": self._send_initialized_notification,
-            "ProgressNotification": self._send_progress_notification,
-            "CancelledNotification": self._send_cancelled_notification,
-            "ListToolsRequest": self._send_list_tools_request,
-            "CallToolRequest": self._send_call_tool_request,
-            "ListResourcesRequest": self._send_list_resources_request,
-            READ_RESOURCE_REQUEST: self._send_read_resource_request,
-            "ListResourceTemplatesRequest": self._send_list_resource_templates_request,
-            "SetLevelRequest": self._send_set_level_request,
-            "CreateMessageRequest": self._send_create_message_request,
-            "ListPromptsRequest": self._send_list_prompts_request,
-            GET_PROMPT_REQUEST: self._send_get_prompt_request,
-            "ListRootsRequest": self._send_list_roots_request,
-            "SubscribeRequest": self._send_subscribe_request,
-            "UnsubscribeRequest": self._send_unsubscribe_request,
-            "CompleteRequest": self._send_complete_request,
-            "ElicitRequest": self._send_elicit_request,
-            "ListTasksRequest": self._send_list_tasks_request,
-            "GetTaskRequest": self._send_get_task_request,
-            "GetTaskPayloadRequest": self._send_get_task_payload_request,
-            "CancelTaskRequest": self._send_cancel_task_request,
-            "PingRequest": self._send_ping_request,
-        }.get(protocol_type, self._send_generic_request)
+        spec = _PROTOCOL_SPECS.get(protocol_type)
+        handler_name = (
+            spec["handler_name"] if spec is not None else "_send_generic_request"
+        )
+        handler = getattr(self, handler_name)
         return await handler(data)
 
     async def _send_notification(self, method: str, data: Any) -> dict[str, str]:
@@ -810,95 +905,104 @@ class ProtocolClient:
 
     async def _send_initialize_request(self, data: Any) -> dict[str, Any]:
         """Send an initialize request."""
-        return await self._send_request("initialize", data)
+        return await self._send_protocol_action("InitializeRequest", data)
 
     async def _send_initialized_notification(self, data: Any) -> dict[str, str]:
         """Send the initialized notification."""
-        return await self._send_notification("notifications/initialized", data)
+        return await self._send_protocol_action("InitializedNotification", data)
 
     async def _send_progress_notification(self, data: Any) -> dict[str, str]:
         """Send a progress notification as JSON-RPC notification (no id)."""
-        return await self._send_notification("notifications/progress", data)
+        return await self._send_protocol_action("ProgressNotification", data)
 
     async def _send_cancelled_notification(self, data: Any) -> dict[str, str]:
         """Send a cancelled notification as JSON-RPC notification (no id)."""
-        return await self._send_notification("notifications/cancelled", data)
+        return await self._send_protocol_action("CancelledNotification", data)
 
     async def _send_list_tools_request(self, data: Any) -> dict[str, Any]:
         """Send a list tools request."""
-        return await self._send_request("tools/list", data)
+        return await self._send_protocol_action("ListToolsRequest", data)
 
     async def _send_call_tool_request(self, data: Any) -> dict[str, Any]:
         """Send a tool call request."""
-        return await self._send_request("tools/call", data)
+        return await self._send_protocol_action("CallToolRequest", data)
 
     async def _send_list_resources_request(self, data: Any) -> dict[str, Any]:
         """Send a list resources request."""
-        return await self._send_request("resources/list", data)
+        return await self._send_protocol_action("ListResourcesRequest", data)
 
     async def _send_read_resource_request(self, data: Any) -> dict[str, Any]:
         """Send a read resource request."""
-        return await self._send_request("resources/read", data)
+        return await self._send_protocol_action(READ_RESOURCE_REQUEST, data)
 
     async def _send_list_resource_templates_request(self, data: Any) -> dict[str, Any]:
         """Send a list resource templates request."""
-        return await self._send_request("resources/templates/list", data)
+        return await self._send_protocol_action("ListResourceTemplatesRequest", data)
 
     async def _send_set_level_request(self, data: Any) -> dict[str, Any]:
         """Send a set level request."""
-        return await self._send_request("logging/setLevel", data)
+        return await self._send_protocol_action("SetLevelRequest", data)
 
     async def _send_create_message_request(self, data: Any) -> dict[str, Any]:
         """Send a create message request."""
-        return await self._send_request("sampling/createMessage", data)
+        return await self._send_protocol_action("CreateMessageRequest", data)
 
     async def _send_list_prompts_request(self, data: Any) -> dict[str, Any]:
         """Send a list prompts request."""
-        return await self._send_request("prompts/list", data)
+        return await self._send_protocol_action("ListPromptsRequest", data)
 
     async def _send_get_prompt_request(self, data: Any) -> dict[str, Any]:
         """Send a get prompt request."""
-        return await self._send_request("prompts/get", data)
+        return await self._send_protocol_action(GET_PROMPT_REQUEST, data)
 
     async def _send_list_roots_request(self, data: Any) -> dict[str, Any]:
         """Send a list roots request."""
-        return await self._send_request("roots/list", data)
+        return await self._send_protocol_action("ListRootsRequest", data)
 
     async def _send_subscribe_request(self, data: Any) -> dict[str, Any]:
         """Send a subscribe request."""
-        return await self._send_request("resources/subscribe", data)
+        return await self._send_protocol_action("SubscribeRequest", data)
 
     async def _send_unsubscribe_request(self, data: Any) -> dict[str, Any]:
         """Send an unsubscribe request."""
-        return await self._send_request("resources/unsubscribe", data)
+        return await self._send_protocol_action("UnsubscribeRequest", data)
 
     async def _send_complete_request(self, data: Any) -> dict[str, Any]:
         """Send a complete request."""
-        return await self._send_request("completion/complete", data)
+        return await self._send_protocol_action("CompleteRequest", data)
 
     async def _send_elicit_request(self, data: Any) -> dict[str, Any]:
         """Send an elicitation request."""
-        return await self._send_request("elicitation/create", data)
+        return await self._send_protocol_action("ElicitRequest", data)
 
     async def _send_list_tasks_request(self, data: Any) -> dict[str, Any]:
         """Send a list tasks request."""
-        return await self._send_request("tasks/list", data)
+        return await self._send_protocol_action("ListTasksRequest", data)
 
     async def _send_get_task_request(self, data: Any) -> dict[str, Any]:
         """Send a get task request."""
-        return await self._send_request("tasks/get", data)
+        return await self._send_protocol_action("GetTaskRequest", data)
 
     async def _send_get_task_payload_request(self, data: Any) -> dict[str, Any]:
         """Send a get task payload request."""
-        return await self._send_request("tasks/result", data)
+        return await self._send_protocol_action("GetTaskPayloadRequest", data)
 
     async def _send_cancel_task_request(self, data: Any) -> dict[str, Any]:
         """Send a cancel task request."""
-        return await self._send_request("tasks/cancel", data)
+        return await self._send_protocol_action("CancelTaskRequest", data)
 
     async def _send_ping_request(self, data: Any) -> dict[str, Any]:
         """Send a ping request."""
-        return await self._send_request("ping", data)
+        return await self._send_protocol_action("PingRequest", data)
+
+    async def _send_protocol_action(
+        self, protocol_type: str, data: Any
+    ) -> dict[str, Any] | dict[str, str]:
+        spec = _PROTOCOL_SPECS[protocol_type]
+        method = spec["method"]
+        if spec["is_notification"]:
+            return await self._send_notification(method, data)
+        return await self._send_request(method, data)
 
     async def _send_request(self, method: str, data: Any) -> dict[str, Any]:
         return await self.transport.send_request(method, self._extract_params(data))

--- a/mcp_fuzzer/client/protocol_client.py
+++ b/mcp_fuzzer/client/protocol_client.py
@@ -21,12 +21,10 @@ from ..utils.schema_helpers import _build_tool_arguments, _tool_task_support
 from ..fuzz_engine.mutators import ProtocolMutator
 from ..fuzz_engine.mutators.seed_mutation import mutate_seed_payload
 from .. import spec_guard
-from ..fuzz_engine.executor import ProtocolExecutor
 from ..safety_system.safety import CombinedSafetyProvider, ProtocolSafetyProvider
 
-# Centralized allow-list for protocol types that can be fuzzed.
-# This should stay in sync with ProtocolExecutor.PROTOCOL_TYPES.
-ALLOWED_PROTOCOL_TYPES = frozenset(EXECUTABLE_PROTOCOL_TYPES)
+# ProtocolClient owns the executable protocol list it can iterate over.
+SUPPORTED_PROTOCOL_TYPES = tuple(EXECUTABLE_PROTOCOL_TYPES)
 
 
 class ProtocolClient:
@@ -458,17 +456,7 @@ class ProtocolClient:
         Returns:
             List of protocol type strings
         """
-        try:
-            # Use the class-level protocol type list from ProtocolExecutor
-            # Filter to only request/notification types (exclude result types)
-            return [
-                pt
-                for pt in getattr(ProtocolExecutor, "PROTOCOL_TYPES", ())
-                if pt in ALLOWED_PROTOCOL_TYPES
-            ]
-        except Exception as e:
-            self._logger.error(f"Failed to get protocol types: {e}")
-            return []
+        return list(SUPPORTED_PROTOCOL_TYPES)
 
     async def fuzz_all_protocol_types(
         self, runs_per_type: int = 5, phase: str = "realistic"

--- a/mcp_fuzzer/client/tool_client.py
+++ b/mcp_fuzzer/client/tool_client.py
@@ -61,6 +61,130 @@ class ToolClient:
         self._logger = logging.getLogger(__name__)
         self._tool_schema_checks: dict[str, list[dict[str, Any]]] = {}
 
+    @staticmethod
+    def _build_tool_run_result(
+        *,
+        args: dict[str, Any] | None,
+        label: str | None,
+        success: bool,
+        safety_blocked: bool,
+        safety_sanitized: bool,
+        result: Any = None,
+        error: str | None = None,
+        exception: str | None = None,
+        spec_checks: list[dict[str, Any]] | None = None,
+        spec_scope: str | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "args": args,
+            "success": success,
+            "safety_blocked": safety_blocked,
+            "safety_sanitized": safety_sanitized,
+        }
+        if label is not None:
+            payload["label"] = label
+        if result is not None:
+            payload["result"] = result
+        if error is not None:
+            payload["error"] = error
+        if exception is not None:
+            payload["exception"] = exception
+        if spec_checks:
+            payload["spec_checks"] = spec_checks
+        if spec_scope is not None:
+            payload["spec_scope"] = spec_scope
+        return payload
+
+    @staticmethod
+    def _build_phase_error(tool_name: str, message: str) -> dict[str, Any]:
+        return {
+            "runs": [
+                ToolClient._build_tool_run_result(
+                    args=None,
+                    label=f"tool:{tool_name}",
+                    success=False,
+                    safety_blocked=False,
+                    safety_sanitized=False,
+                    error="phase_execution_failed",
+                    exception=message,
+                )
+            ],
+            "error": message,
+        }
+
+    async def _execute_tool_call(
+        self,
+        tool_name: str,
+        args: dict[str, Any],
+        *,
+        label: str | None = None,
+    ) -> dict[str, Any]:
+        """Run one fuzzed tool call through safety, auth, RPC, and result shaping."""
+        if self.safety_system and self.safety_system.should_skip_tool_call(
+            tool_name, args
+        ):
+            self._logger.warning("Safety system blocked tool call for %s", tool_name)
+            return self._build_tool_run_result(
+                args=args,
+                label=label,
+                success=False,
+                safety_blocked=True,
+                safety_sanitized=False,
+                error="safety_blocked",
+            )
+
+        sanitized_args = args
+        safety_sanitized = False
+        if self.safety_system:
+            sanitized_args = self.safety_system.sanitize_tool_arguments(
+                tool_name, args
+            )
+            safety_sanitized = sanitized_args != args
+
+        auth_params = self.auth_manager.get_auth_params_for_tool(tool_name)
+
+        # Merge auth params only into the call payload; never persist secrets.
+        args_for_call = {**sanitized_args}
+        if auth_params:
+            args_for_call.update(auth_params)
+
+        try:
+            result = await self._rpc.call_tool(tool_name, args_for_call)
+            spec_checks = spec_guard.check_tool_result_content(result)
+            response_signature = _response_shape_signature(result)
+            self.tool_mutator.record_feedback(
+                tool_name,
+                sanitized_args,
+                spec_checks=spec_checks,
+                response_signature=response_signature,
+            )
+            call_result = self._build_tool_run_result(
+                args=sanitized_args,
+                label=label,
+                success=True,
+                safety_blocked=False,
+                safety_sanitized=safety_sanitized,
+                result=result,
+                spec_checks=spec_checks,
+                spec_scope="tool_result" if spec_checks else None,
+            )
+        except Exception as e:
+            self._logger.warning("Exception calling tool %s: %s", tool_name, e)
+            self.tool_mutator.record_feedback(
+                tool_name, sanitized_args, exception=str(e)
+            )
+            call_result = self._build_tool_run_result(
+                args=sanitized_args,
+                label=label,
+                success=False,
+                safety_blocked=False,
+                safety_sanitized=safety_sanitized,
+                error="tool_call_failed",
+                exception=str(e),
+            )
+
+        return call_result
+
     async def _get_tools_from_server(self) -> list[dict[str, Any]]:
         """Get tools from the server.
 
@@ -126,14 +250,29 @@ class ToolClient:
                 ):
                     pass
                 return [
-                    {
-                        "error": "tool_timeout",
-                        "exception": "Tool fuzzing timed out",
-                    }
+                    self._build_tool_run_result(
+                        args=None,
+                        label=f"tool:{tool_name}",
+                        success=False,
+                        safety_blocked=False,
+                        safety_sanitized=False,
+                        error="tool_timeout",
+                        exception="Tool fuzzing timed out",
+                    )
                 ]
         except Exception as e:
             self._logger.error(f"Failed to fuzz tool {tool_name}: {e}")
-            return [{"error": str(e)}]
+            return [
+                self._build_tool_run_result(
+                    args=None,
+                    label=f"tool:{tool_name}",
+                    success=False,
+                    safety_blocked=False,
+                    safety_sanitized=False,
+                    error=str(e),
+                    exception=str(e),
+                )
+            ]
 
     async def fuzz_tool(
         self,
@@ -150,94 +289,28 @@ class ToolClient:
                 # Generate fuzz arguments using the mutator
                 args = await self.tool_mutator.mutate(tool)
 
-                # Check safety before proceeding
-                if self.safety_system and self.safety_system.should_skip_tool_call(
-                    tool_name, args
-                ):
-                    self._logger.warning(
-                        "Safety system blocked tool call for %s", tool_name
-                    )
-                    results.append(
-                        {
-                            "args": args,
-                            "exception": "safety_blocked",
-                            "safety_blocked": True,
-                            "safety_sanitized": False,
-                        }
-                    )
-                    continue
-
-                # Sanitize arguments if safety system is enabled
-                sanitized_args = args
-                safety_sanitized = False
-                if self.safety_system:
-                    sanitized_args = self.safety_system.sanitize_tool_arguments(
-                        tool_name, args
-                    )
-                    safety_sanitized = sanitized_args != args
-
-                # Get authentication for this tool
-                auth_params = self.auth_manager.get_auth_params_for_tool(tool_name)
-
-                # Merge auth params only into the call payload; never persist secrets
-                args_for_call = {**sanitized_args}
-                if auth_params:
-                    args_for_call.update(auth_params)
-
                 # High-level run progress at DEBUG to avoid noise
                 self._logger.debug("Fuzzing %s (run %d/%d)", tool_name, i + 1, runs)
-
-                # Call the tool with the generated arguments
-                try:
-                    result = await self._rpc.call_tool(tool_name, args_for_call)
-                    spec_checks = spec_guard.check_tool_result_content(result)
-                    spec_payload = (
-                        {"spec_checks": spec_checks, "spec_scope": "tool_result"}
-                        if spec_checks
-                        else {}
-                    )
-                    response_signature = _response_shape_signature(result)
-                    self.tool_mutator.record_feedback(
+                results.append(
+                    await self._execute_tool_call(
                         tool_name,
-                        sanitized_args,
-                        spec_checks=spec_checks,
-                        response_signature=response_signature,
+                        args,
+                        label=f"tool:{tool_name}",
                     )
-                    results.append(
-                        {
-                            "args": sanitized_args,
-                            "result": result,
-                            "safety_blocked": False,
-                            "safety_sanitized": safety_sanitized,
-                            "success": True,
-                            **spec_payload,
-                        }
-                    )
-                except Exception as e:
-                    self._logger.warning("Exception calling tool %s: %s", tool_name, e)
-                    self.tool_mutator.record_feedback(
-                        tool_name, sanitized_args, exception=str(e)
-                    )
-                    results.append(
-                        {
-                            "args": sanitized_args,
-                            "exception": str(e),
-                            "safety_blocked": False,
-                            "safety_sanitized": safety_sanitized,
-                            "success": False,
-                        }
-                    )
+                )
 
             except Exception as e:
                 self._logger.warning("Exception during fuzzing %s: %s", tool_name, e)
                 results.append(
-                    {
-                        "args": None,
-                        "exception": str(e),
-                        "safety_blocked": False,
-                        "safety_sanitized": False,
-                        "success": False,
-                    }
+                    self._build_tool_run_result(
+                        args=None,
+                        label=f"tool:{tool_name}",
+                        success=False,
+                        safety_blocked=False,
+                        safety_sanitized=False,
+                        error="tool_mutation_failed",
+                        exception=str(e),
+                    )
                 )
 
         return results
@@ -341,13 +414,13 @@ class ToolClient:
                 self._logger.error(
                     f"Error in two-phase fuzzing {tool_name}: {phase_results['error']}"
                 )
-                return {"error": phase_results["error"]}
+                return phase_results
 
             return phase_results
 
         except Exception as e:
             self._logger.error(f"Error in two-phase fuzzing {tool_name}: {e}")
-            return {"error": str(e)}
+            return self._build_phase_error(tool_name, str(e))
 
     async def _process_fuzz_results(
         self,
@@ -366,81 +439,13 @@ class ToolClient:
         processed = []
         for fuzz_result in fuzz_results:
             args = fuzz_result["args"]
-
-            # Skip if safety system blocks this call
-            if self.safety_system and self.safety_system.should_skip_tool_call(
-                tool_name, args
-            ):
-                processed.append(
-                    {
-                        "args": args,
-                        "label": f"tool:{tool_name}",
-                        "exception": "safety_blocked",
-                        "safety_blocked": True,
-                        "safety_sanitized": False,
-                        "success": False,
-                    }
-                )
-                continue
-
-            # Sanitize arguments if needed
-            sanitized_args = args
-            safety_sanitized = False
-            if self.safety_system:
-                sanitized_args = self.safety_system.sanitize_tool_arguments(
-                    tool_name, args
-                )
-                safety_sanitized = sanitized_args != args
-
-            # Get authentication for this tool
-            auth_params = self.auth_manager.get_auth_params_for_tool(tool_name)
-
-            # Merge auth params only into call payload
-            args_for_call = {**sanitized_args}
-            if auth_params:
-                args_for_call.update(auth_params)
-
-            # Call the tool with the generated arguments
-            try:
-                result = await self._rpc.call_tool(tool_name, args_for_call)
-                spec_checks = spec_guard.check_tool_result_content(result)
-                spec_payload = (
-                    {"spec_checks": spec_checks, "spec_scope": "tool_result"}
-                    if spec_checks
-                    else {}
-                )
-                response_signature = _response_shape_signature(result)
-                self.tool_mutator.record_feedback(
+            processed.append(
+                await self._execute_tool_call(
                     tool_name,
-                    sanitized_args,
-                    spec_checks=spec_checks,
-                    response_signature=response_signature,
+                    args,
+                    label=f"tool:{tool_name}",
                 )
-                processed.append(
-                    {
-                        "args": sanitized_args,
-                        "label": f"tool:{tool_name}",
-                        "result": result,
-                        "safety_blocked": False,
-                        "safety_sanitized": safety_sanitized,
-                        "success": True,
-                        **spec_payload,
-                    }
-                )
-            except Exception as e:
-                self.tool_mutator.record_feedback(
-                    tool_name, sanitized_args, exception=str(e)
-                )
-                processed.append(
-                    {
-                        "args": sanitized_args,
-                        "label": f"tool:{tool_name}",
-                        "exception": str(e),
-                        "safety_blocked": False,
-                        "safety_sanitized": safety_sanitized,
-                        "success": False,
-                    }
-                )
+            )
 
         return processed
 
@@ -481,7 +486,7 @@ class ToolClient:
             self._logger.error(
                 f"Error during two-phase fuzzing of tool {tool_name}: {e}"
             )
-            return {"error": str(e)}
+            return self._build_phase_error(tool_name, str(e))
 
     async def fuzz_all_tools_both_phases(
         self, runs_per_phase: int = 5

--- a/mcp_fuzzer/client/tool_client.py
+++ b/mcp_fuzzer/client/tool_client.py
@@ -72,6 +72,7 @@ class ToolClient:
         result: Any = None,
         error: str | None = None,
         exception: str | None = None,
+        timeout_scope: str | None = None,
         spec_checks: list[dict[str, Any]] | None = None,
         spec_scope: str | None = None,
     ) -> dict[str, Any]:
@@ -89,6 +90,8 @@ class ToolClient:
             payload["error"] = error
         if exception is not None:
             payload["exception"] = exception
+        if timeout_scope is not None:
+            payload["timeout_scope"] = timeout_scope
         if spec_checks:
             payload["spec_checks"] = spec_checks
         if spec_scope is not None:
@@ -118,6 +121,7 @@ class ToolClient:
         args: dict[str, Any],
         *,
         label: str | None = None,
+        tool_timeout: float | None = None,
     ) -> dict[str, Any]:
         """Run one fuzzed tool call through safety, auth, RPC, and result shaping."""
         if self.safety_system and self.safety_system.should_skip_tool_call(
@@ -149,7 +153,9 @@ class ToolClient:
             args_for_call.update(auth_params)
 
         try:
-            result = await self._rpc.call_tool(tool_name, args_for_call)
+            result = await self._call_tool(
+                tool_name, args_for_call, tool_timeout=tool_timeout
+            )
             spec_checks = spec_guard.check_tool_result_content(result)
             response_signature = _response_shape_signature(result)
             self.tool_mutator.record_feedback(
@@ -168,6 +174,24 @@ class ToolClient:
                 spec_checks=spec_checks,
                 spec_scope="tool_result" if spec_checks else None,
             )
+        except asyncio.TimeoutError:
+            exception = self._tool_timeout_message(tool_timeout)
+            self._logger.warning("Tool %s call timed out: %s", tool_name, exception)
+            self.tool_mutator.record_feedback(
+                tool_name,
+                sanitized_args,
+                exception=exception,
+            )
+            call_result = self._build_tool_run_result(
+                args=sanitized_args,
+                label=label,
+                success=False,
+                safety_blocked=False,
+                safety_sanitized=safety_sanitized,
+                error="tool_timeout",
+                exception=exception,
+                timeout_scope="call",
+            )
         except Exception as e:
             self._logger.warning("Exception calling tool %s: %s", tool_name, e)
             self.tool_mutator.record_feedback(
@@ -184,6 +208,26 @@ class ToolClient:
             )
 
         return call_result
+
+    async def _call_tool(
+        self,
+        tool_name: str,
+        args_for_call: dict[str, Any],
+        *,
+        tool_timeout: float | None = None,
+    ) -> Any:
+        if tool_timeout is None:
+            return await self._rpc.call_tool(tool_name, args_for_call)
+        return await asyncio.wait_for(
+            self._rpc.call_tool(tool_name, args_for_call),
+            timeout=tool_timeout,
+        )
+
+    @staticmethod
+    def _tool_timeout_message(tool_timeout: float | None) -> str:
+        if tool_timeout is None:
+            return "Tool execution timed out"
+        return f"Tool execution timed out after {tool_timeout}s"
 
     async def _get_tools_from_server(self) -> list[dict[str, Any]]:
         """Get tools from the server.
@@ -258,6 +302,7 @@ class ToolClient:
                         safety_sanitized=False,
                         error="tool_timeout",
                         exception="Tool fuzzing timed out",
+                        timeout_scope="session",
                     )
                 ]
         except Exception as e:
@@ -296,6 +341,7 @@ class ToolClient:
                         tool_name,
                         args,
                         label=f"tool:{tool_name}",
+                        tool_timeout=tool_timeout,
                     )
                 )
 
@@ -426,6 +472,8 @@ class ToolClient:
         self,
         tool_name: str,
         fuzz_results: list[dict[str, Any]],
+        *,
+        tool_timeout: float | None = None,
     ) -> list[dict[str, Any]]:
         """Process fuzz results with safety checks and tool calls.
 
@@ -444,10 +492,30 @@ class ToolClient:
                     tool_name,
                     args,
                     label=f"tool:{tool_name}",
+                    tool_timeout=tool_timeout,
                 )
             )
 
         return processed
+
+    async def _run_tool_phase(
+        self,
+        tool: dict[str, Any],
+        *,
+        phase_name: str,
+        mutate_phase: str | None,
+        runs: int,
+    ) -> list[dict[str, Any]]:
+        tool_name = tool.get("name", "unknown")
+        self._logger.info("%s phase: %s", phase_name.title(), tool_name)
+        fuzz_results = []
+        for _ in range(runs):
+            if mutate_phase is None:
+                args = await self.tool_mutator.mutate(tool)
+            else:
+                args = await self.tool_mutator.mutate(tool, phase=mutate_phase)
+            fuzz_results.append({"args": args})
+        return await self._process_fuzz_results(tool_name, fuzz_results)
 
     async def fuzz_tool_both_phases(
         self, tool: dict[str, Any], runs_per_phase: int = 5
@@ -457,24 +525,17 @@ class ToolClient:
         self._logger.info(f"Starting two-phase fuzzing for tool: {tool_name}")
 
         try:
-            # Phase 1: Realistic fuzzing
-            self._logger.info(f"Phase 1 (Realistic): {tool_name}")
-            realistic_results = []
-            for i in range(runs_per_phase):
-                args = await self.tool_mutator.mutate(tool, phase="realistic")
-                realistic_results.append({"args": args})
-            realistic_processed = await self._process_fuzz_results(
-                tool_name, realistic_results
+            realistic_processed = await self._run_tool_phase(
+                tool,
+                phase_name="realistic",
+                mutate_phase="realistic",
+                runs=runs_per_phase,
             )
-
-            # Phase 2: Aggressive fuzzing
-            self._logger.info(f"Phase 2 (Aggressive): {tool_name}")
-            aggressive_results = []
-            for i in range(runs_per_phase):
-                args = await self.tool_mutator.mutate(tool)
-                aggressive_results.append({"args": args})
-            aggressive_processed = await self._process_fuzz_results(
-                tool_name, aggressive_results
+            aggressive_processed = await self._run_tool_phase(
+                tool,
+                phase_name="aggressive",
+                mutate_phase=None,
+                runs=runs_per_phase,
             )
 
             return {

--- a/mcp_fuzzer/client/tool_client.py
+++ b/mcp_fuzzer/client/tool_client.py
@@ -14,6 +14,7 @@ from ..auth import AuthManager
 from .. import spec_guard
 from ..fuzz_engine.mutators import ToolMutator
 from ..safety_system.safety import SafetyFilter, CombinedSafetyProvider
+from ..types import ErrorType, TimeoutScope, ToolRunResult
 
 # Import constants directly from config (constants are values, not behavior)
 from ..config.core.constants import (
@@ -70,13 +71,13 @@ class ToolClient:
         safety_blocked: bool,
         safety_sanitized: bool,
         result: Any = None,
-        error: str | None = None,
+        error: ErrorType | None = None,
         exception: str | None = None,
-        timeout_scope: str | None = None,
+        timeout_scope: TimeoutScope | None = None,
         spec_checks: list[dict[str, Any]] | None = None,
         spec_scope: str | None = None,
-    ) -> dict[str, Any]:
-        payload: dict[str, Any] = {
+    ) -> ToolRunResult:
+        payload: ToolRunResult = {
             "args": args,
             "success": success,
             "safety_blocked": safety_blocked,
@@ -108,7 +109,7 @@ class ToolClient:
                     success=False,
                     safety_blocked=False,
                     safety_sanitized=False,
-                    error="phase_execution_failed",
+                    error=ErrorType.PHASE_EXECUTION_FAILED,
                     exception=message,
                 )
             ],
@@ -134,7 +135,7 @@ class ToolClient:
                 success=False,
                 safety_blocked=True,
                 safety_sanitized=False,
-                error="safety_blocked",
+                error=ErrorType.SAFETY_BLOCKED,
             )
 
         sanitized_args = args
@@ -188,9 +189,9 @@ class ToolClient:
                 success=False,
                 safety_blocked=False,
                 safety_sanitized=safety_sanitized,
-                error="tool_timeout",
+                error=ErrorType.TOOL_TIMEOUT,
                 exception=exception,
-                timeout_scope="call",
+                timeout_scope=TimeoutScope.CALL,
             )
         except Exception as e:
             self._logger.warning("Exception calling tool %s: %s", tool_name, e)
@@ -203,7 +204,7 @@ class ToolClient:
                 success=False,
                 safety_blocked=False,
                 safety_sanitized=safety_sanitized,
-                error="tool_call_failed",
+                error=ErrorType.TOOL_CALL_FAILED,
                 exception=str(e),
             )
 
@@ -300,9 +301,9 @@ class ToolClient:
                         success=False,
                         safety_blocked=False,
                         safety_sanitized=False,
-                        error="tool_timeout",
+                        error=ErrorType.TOOL_TIMEOUT,
                         exception="Tool fuzzing timed out",
-                        timeout_scope="session",
+                        timeout_scope=TimeoutScope.SESSION,
                     )
                 ]
         except Exception as e:
@@ -354,7 +355,7 @@ class ToolClient:
                         success=False,
                         safety_blocked=False,
                         safety_sanitized=False,
-                        error="tool_mutation_failed",
+                        error=ErrorType.TOOL_MUTATION_FAILED,
                         exception=str(e),
                     )
                 )

--- a/mcp_fuzzer/client/tool_client.py
+++ b/mcp_fuzzer/client/tool_client.py
@@ -444,7 +444,10 @@ class ToolClient:
         )
 
     async def _fuzz_single_tool_both_phases(
-        self, tool: dict[str, Any], runs_per_phase: int
+        self,
+        tool: dict[str, Any],
+        runs_per_phase: int,
+        tool_timeout: float | None = None,
     ) -> dict[str, Any]:
         """Fuzz a single tool in both phases and report results."""
         tool_name = tool.get("name", "unknown")
@@ -453,7 +456,11 @@ class ToolClient:
 
         try:
             # Run both phases for this tool
-            phase_results = await self.fuzz_tool_both_phases(tool, runs_per_phase)
+            phase_results = await self.fuzz_tool_both_phases(
+                tool,
+                runs_per_phase,
+                tool_timeout=tool_timeout,
+            )
 
             # Check if the result is an error
             if "error" in phase_results:
@@ -505,6 +512,7 @@ class ToolClient:
         phase_name: str,
         mutate_phase: str | None,
         runs: int,
+        tool_timeout: float | None = None,
     ) -> list[dict[str, Any]]:
         tool_name = tool.get("name", "unknown")
         self._logger.info("%s phase: %s", phase_name.title(), tool_name)
@@ -515,10 +523,17 @@ class ToolClient:
             else:
                 args = await self.tool_mutator.mutate(tool, phase=mutate_phase)
             fuzz_results.append({"args": args})
-        return await self._process_fuzz_results(tool_name, fuzz_results)
+        return await self._process_fuzz_results(
+            tool_name,
+            fuzz_results,
+            tool_timeout=tool_timeout,
+        )
 
     async def fuzz_tool_both_phases(
-        self, tool: dict[str, Any], runs_per_phase: int = 5
+        self,
+        tool: dict[str, Any],
+        runs_per_phase: int = 5,
+        tool_timeout: float | None = None,
     ) -> dict[str, Any]:
         """Fuzz a specific tool in both realistic and aggressive phases."""
         tool_name = tool.get("name", "unknown")
@@ -530,12 +545,14 @@ class ToolClient:
                 phase_name="realistic",
                 mutate_phase="realistic",
                 runs=runs_per_phase,
+                tool_timeout=tool_timeout,
             )
             aggressive_processed = await self._run_tool_phase(
                 tool,
                 phase_name="aggressive",
                 mutate_phase=None,
                 runs=runs_per_phase,
+                tool_timeout=tool_timeout,
             )
 
             return {
@@ -550,7 +567,9 @@ class ToolClient:
             return self._build_phase_error(tool_name, str(e))
 
     async def fuzz_all_tools_both_phases(
-        self, runs_per_phase: int = 5
+        self,
+        runs_per_phase: int = 5,
+        tool_timeout: float | None = None,
     ) -> dict[str, dict[str, list[dict[str, Any]]]]:
         """Fuzz all tools in both realistic and aggressive phases."""
         # Use reporter for output instead of console
@@ -567,7 +586,9 @@ class ToolClient:
             for tool in tools:
                 tool_name = tool.get("name", "unknown")
                 phase_results = await self._fuzz_single_tool_both_phases(
-                    tool, runs_per_phase
+                    tool,
+                    runs_per_phase,
+                    tool_timeout=tool_timeout,
                 )
                 if tool_name in self._tool_schema_checks:
                     schema_checks = self._tool_schema_checks[tool_name]

--- a/mcp_fuzzer/client/transport/__init__.py
+++ b/mcp_fuzzer/client/transport/__init__.py
@@ -1,3 +1,3 @@
-from .factory import build_driver_with_auth
+from .factory import TransportBuildRequest, build_driver_with_auth
 
-__all__ = ["build_driver_with_auth"]
+__all__ = ["TransportBuildRequest", "build_driver_with_auth"]

--- a/mcp_fuzzer/client/transport/factory.py
+++ b/mcp_fuzzer/client/transport/factory.py
@@ -3,24 +3,39 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import logging
-import sys
 from typing import Any
-
-from rich.console import Console
-
 from ...transport.catalog import build_driver as base_build_driver
 from ...transport.wrappers import RetryingTransport, RetryPolicy
+from ...exceptions import TransportRegistrationError
 
 logger = logging.getLogger(__name__)
 AUTH_PROTOCOLS = ("http", "https", "streamablehttp", "sse")
 
 
-def build_driver_with_auth(args: Any, client_args: dict[str, Any]):
+@dataclass(frozen=True)
+class TransportBuildRequest:
+    """Typed transport settings used by the client runtime."""
+
+    protocol: str
+    endpoint: str
+    timeout: float = 30.0
+    transport_retries: int = 1
+    transport_retry_delay: float = 0.5
+    transport_retry_backoff: float = 2.0
+    transport_retry_max_delay: float = 5.0
+    transport_retry_jitter: float = 0.1
+    auth_manager: Any = None
+    safety_enabled: bool = True
+
+
+def build_driver_with_auth(request: TransportBuildRequest):
     """Create a transport with authentication headers when available."""
+    resolved = request
     try:
         auth_headers = None
-        auth_manager = client_args.get("auth_manager")
+        auth_manager = resolved.auth_manager
 
         if auth_manager:
             auth_headers = auth_manager.get_default_auth_headers()
@@ -38,26 +53,28 @@ def build_driver_with_auth(args: Any, client_args: dict[str, Any]):
                     "No auth headers found for default tool mapping"
                 )  # pragma: no cover
 
-        factory_kwargs = {"timeout": args.timeout}
-        safety_enabled = client_args.get("safety_enabled", True)
+        factory_kwargs = {"timeout": resolved.timeout}
+        safety_enabled = resolved.safety_enabled
 
-        if args.protocol in AUTH_PROTOCOLS:
+        if resolved.protocol in AUTH_PROTOCOLS:
             factory_kwargs["safety_enabled"] = safety_enabled
-        if args.protocol in AUTH_PROTOCOLS and auth_headers:
+        if resolved.protocol in AUTH_PROTOCOLS and auth_headers:
             factory_kwargs["auth_headers"] = auth_headers
-            logger.debug("Adding auth headers to %s transport", args.protocol.upper())
+            logger.debug(
+                "Adding auth headers to %s transport", resolved.protocol.upper()
+            )
 
         logger.debug(
             "Creating %s transport to %s",
-            args.protocol.upper(),
-            args.endpoint,
+            resolved.protocol.upper(),
+            resolved.endpoint,
         )
         transport = base_build_driver(
-            args.protocol,
-            args.endpoint,
+            resolved.protocol,
+            resolved.endpoint,
             **factory_kwargs,
         )
-        retry_attempts = getattr(args, "transport_retries", 1)
+        retry_attempts = resolved.transport_retries
         try:
             retry_attempts = int(retry_attempts)
         except (TypeError, ValueError):
@@ -65,18 +82,23 @@ def build_driver_with_auth(args: Any, client_args: dict[str, Any]):
         if retry_attempts > 1:
             policy = RetryPolicy(
                 max_attempts=retry_attempts,
-                base_delay=getattr(args, "transport_retry_delay", 0.5),
-                max_delay=getattr(args, "transport_retry_max_delay", 5.0),
-                backoff_factor=getattr(args, "transport_retry_backoff", 2.0),
-                jitter=getattr(args, "transport_retry_jitter", 0.1),
+                base_delay=resolved.transport_retry_delay,
+                max_delay=resolved.transport_retry_max_delay,
+                backoff_factor=resolved.transport_retry_backoff,
+                jitter=resolved.transport_retry_jitter,
             )
             transport = RetryingTransport(transport, policy=policy)
         return transport
     except Exception as transport_error:  # pragma: no cover
-        console = Console()
-        console.print(f"[bold red]Unexpected error:[/bold red] {transport_error}")
         logger.exception("Transport creation failed")
-        sys.exit(1)
+        raise TransportRegistrationError(
+            "Transport creation failed",
+            context={
+                "protocol": getattr(resolved, "protocol", "unknown"),
+                "endpoint": getattr(resolved, "endpoint", "unknown"),
+                "details": str(transport_error),
+            },
+        ) from transport_error
 
 
-__all__ = ["build_driver_with_auth"]
+__all__ = ["TransportBuildRequest", "build_driver_with_auth"]

--- a/mcp_fuzzer/client/transport/factory.py
+++ b/mcp_fuzzer/client/transport/factory.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
-from typing import Any
 from ...transport.catalog import build_driver as base_build_driver
 from ...transport.wrappers import RetryingTransport, RetryPolicy
 from ...exceptions import TransportRegistrationError
+from ...types import AuthManagerProtocol
 
 logger = logging.getLogger(__name__)
 AUTH_PROTOCOLS = ("http", "https", "streamablehttp", "sse")
@@ -26,7 +26,7 @@ class TransportBuildRequest:
     transport_retry_backoff: float = 2.0
     transport_retry_max_delay: float = 5.0
     transport_retry_jitter: float = 0.1
-    auth_manager: Any = None
+    auth_manager: AuthManagerProtocol | None = None
     safety_enabled: bool = True
 
 

--- a/mcp_fuzzer/reports/formatters/common.py
+++ b/mcp_fuzzer/reports/formatters/common.py
@@ -96,7 +96,11 @@ def summarize_tool_runs(runs: list[dict[str, Any]]) -> dict[str, int | float]:
     """Return non-overlapping summary counters for tool run reporting."""
     total_runs = len(runs)
     exceptions = sum(1 for run in runs if tool_run_has_exception(run))
-    safety_blocked = sum(1 for run in runs if run.get("safety_blocked", False))
+    safety_blocked = sum(
+        1
+        for run in runs
+        if isinstance(run, dict) and run.get("safety_blocked", False)
+    )
     failures = sum(1 for run in runs if tool_run_has_failure(run))
     successful = max(total_runs - failures, 0)
     success_rate = (successful / total_runs) * 100 if total_runs > 0 else 0.0

--- a/mcp_fuzzer/reports/formatters/common.py
+++ b/mcp_fuzzer/reports/formatters/common.py
@@ -38,6 +38,23 @@ def extract_tool_runs(
         combined.extend(realistic)
     if isinstance(aggressive, list):
         combined.extend(aggressive)
+    if combined:
+        return combined, tool_entry
+    if "error" in tool_entry or "exception" in tool_entry:
+        synthetic_run: dict[str, Any] = {
+            "success": bool(tool_entry.get("success", False)),
+            "safety_blocked": bool(tool_entry.get("safety_blocked", False)),
+            "safety_sanitized": bool(tool_entry.get("safety_sanitized", False)),
+        }
+        if "args" in tool_entry:
+            synthetic_run["args"] = tool_entry.get("args")
+        if "label" in tool_entry:
+            synthetic_run["label"] = tool_entry.get("label")
+        if "error" in tool_entry:
+            synthetic_run["error"] = tool_entry.get("error")
+        if "exception" in tool_entry:
+            synthetic_run["exception"] = tool_entry.get("exception")
+        return [synthetic_run], tool_entry
     return combined, tool_entry
 
 
@@ -50,6 +67,50 @@ def calculate_tool_success_rate(
         return 0.0
     successful_runs = max(0, total_runs - exceptions - safety_blocked)
     return (successful_runs / total_runs) * 100
+
+
+def tool_run_has_exception(result: dict[str, Any] | None) -> bool:
+    """Return True when a tool result has a non-safety exception."""
+    if not isinstance(result, dict):
+        return False
+    if result.get("safety_blocked", False):
+        return False
+    return bool(result.get("exception"))
+
+
+def tool_run_has_failure(result: dict[str, Any] | None) -> bool:
+    """Return True when a tool result should count as a failed run."""
+    if not isinstance(result, dict):
+        return True
+    if result.get("safety_blocked", False):
+        return True
+    return bool(
+        tool_run_has_exception(result)
+        or not result.get("success", True)
+        or result.get("error")
+        or result.get("server_error")
+    )
+
+
+def summarize_tool_runs(runs: list[dict[str, Any]]) -> dict[str, int | float]:
+    """Return non-overlapping summary counters for tool run reporting."""
+    total_runs = len(runs)
+    exceptions = sum(1 for run in runs if tool_run_has_exception(run))
+    safety_blocked = sum(1 for run in runs if run.get("safety_blocked", False))
+    failures = sum(1 for run in runs if tool_run_has_failure(run))
+    successful = max(total_runs - failures, 0)
+    return {
+        "total_runs": total_runs,
+        "exceptions": exceptions,
+        "safety_blocked": safety_blocked,
+        "failures": failures,
+        "successful": successful,
+        "success_rate": calculate_tool_success_rate(
+            total_runs,
+            exceptions,
+            safety_blocked,
+        ),
+    }
 
 
 def calculate_protocol_success_rate(total_runs: int, errors: int) -> float:

--- a/mcp_fuzzer/reports/formatters/common.py
+++ b/mcp_fuzzer/reports/formatters/common.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Iterable, Literal, Protocol
 
+from ...types import ExtractedToolRuns, ToolRunResult
+
 
 class SupportsToDict(Protocol):
     def to_dict(self) -> dict[str, Any]: ...
@@ -23,15 +25,15 @@ def normalize_report_data(
 
 def extract_tool_runs(
     tool_entry: Any,
-) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+) -> ExtractedToolRuns:
     if isinstance(tool_entry, list):
-        return tool_entry, None
+        return ExtractedToolRuns(tool_entry, None)
     if not isinstance(tool_entry, dict):
-        return [], None
+        return ExtractedToolRuns([], None)
     runs = tool_entry.get("runs")
     if isinstance(runs, list):
-        return runs, tool_entry
-    combined: list[dict[str, Any]] = []
+        return ExtractedToolRuns(runs, tool_entry)
+    combined: list[ToolRunResult] = []
     realistic = tool_entry.get("realistic")
     aggressive = tool_entry.get("aggressive")
     if isinstance(realistic, list):
@@ -39,9 +41,9 @@ def extract_tool_runs(
     if isinstance(aggressive, list):
         combined.extend(aggressive)
     if combined:
-        return combined, tool_entry
+        return ExtractedToolRuns(combined, tool_entry)
     if "error" in tool_entry or "exception" in tool_entry:
-        synthetic_run: dict[str, Any] = {
+        synthetic_run: ToolRunResult = {
             "success": bool(tool_entry.get("success", False)),
             "safety_blocked": bool(tool_entry.get("safety_blocked", False)),
             "safety_sanitized": bool(tool_entry.get("safety_sanitized", False)),
@@ -54,8 +56,8 @@ def extract_tool_runs(
             synthetic_run["error"] = tool_entry.get("error")
         if "exception" in tool_entry:
             synthetic_run["exception"] = tool_entry.get("exception")
-        return [synthetic_run], tool_entry
-    return combined, tool_entry
+        return ExtractedToolRuns([synthetic_run], tool_entry)
+    return ExtractedToolRuns(combined, tool_entry)
 
 
 def calculate_tool_success_rate(
@@ -79,7 +81,13 @@ def tool_run_has_exception(result: dict[str, Any] | None) -> bool:
 
 
 def tool_run_has_failure(result: dict[str, Any] | None) -> bool:
-    """Return True when a tool result should count as a failed run."""
+    """Return True when a tool result should count as a failed run.
+
+    Failure classification rules are centralized here:
+    - malformed/non-dict entries are failures
+    - safety-blocked entries are failures
+    - exceptions, explicit errors, server errors, or falsey success are failures
+    """
     if not isinstance(result, dict):
         return True
     if result.get("safety_blocked", False):

--- a/mcp_fuzzer/reports/formatters/common.py
+++ b/mcp_fuzzer/reports/formatters/common.py
@@ -99,17 +99,14 @@ def summarize_tool_runs(runs: list[dict[str, Any]]) -> dict[str, int | float]:
     safety_blocked = sum(1 for run in runs if run.get("safety_blocked", False))
     failures = sum(1 for run in runs if tool_run_has_failure(run))
     successful = max(total_runs - failures, 0)
+    success_rate = (successful / total_runs) * 100 if total_runs > 0 else 0.0
     return {
         "total_runs": total_runs,
         "exceptions": exceptions,
         "safety_blocked": safety_blocked,
         "failures": failures,
         "successful": successful,
-        "success_rate": calculate_tool_success_rate(
-            total_runs,
-            exceptions,
-            safety_blocked,
-        ),
+        "success_rate": success_rate,
     }
 
 

--- a/mcp_fuzzer/reports/formatters/console.py
+++ b/mcp_fuzzer/reports/formatters/console.py
@@ -9,10 +9,10 @@ from rich.table import Table
 
 from .common import (
     calculate_protocol_success_rate,
-    calculate_tool_success_rate,
     collect_and_summarize_protocol_items,
     extract_tool_runs,
     result_has_failure,
+    summarize_tool_runs,
 )
 from ...protocol_types import GET_PROMPT_REQUEST, READ_RESOURCE_REQUEST
 
@@ -38,22 +38,64 @@ class ConsoleFormatter:
 
         for tool_name, tool_results in results.items():
             runs, _ = extract_tool_runs(tool_results)
-            total_runs = len(runs)
-            exceptions = sum(1 for r in runs if "exception" in r)
-            safety_blocked = sum(1 for r in runs if r.get("safety_blocked", False))
-            success_rate = calculate_tool_success_rate(
-                total_runs, exceptions, safety_blocked
-            )
+            stats = summarize_tool_runs(runs)
 
             table.add_row(
                 tool_name,
-                str(total_runs),
-                str(exceptions),
-                str(safety_blocked),
-                f"{success_rate:.1f}%",
+                str(stats["total_runs"]),
+                str(stats["exceptions"]),
+                str(stats["safety_blocked"]),
+                f"{stats['success_rate']:.1f}%",
             )
 
         self.console.print(table)
+
+    def print_tool_execution_summary(self, results: dict[str, Any]) -> None:
+        """Print the detailed tool execution summary and aggregate statistics."""
+        self.print_tool_summary(results)
+        if not results:
+            return
+
+        total_tools = len(results)
+        total_runs = 0
+        total_exceptions = 0
+        total_failures = 0
+        vulnerable_tools: list[tuple[str, int, int]] = []
+
+        for tool_name, tool_results in results.items():
+            runs, _ = extract_tool_runs(tool_results)
+            stats = summarize_tool_runs(runs)
+            total_runs += int(stats["total_runs"])
+            total_exceptions += int(stats["exceptions"])
+            total_failures += int(stats["failures"])
+            if stats["failures"] > 0:
+                vulnerable_tools.append(
+                    (tool_name, int(stats["failures"]), int(stats["total_runs"]))
+                )
+
+        success_rate = (
+            ((total_runs - total_failures) / total_runs * 100)
+            if total_runs > 0
+            else 0
+        )
+
+        self.console.print("\n[bold]Tool Execution Statistics[/bold]")
+        self.console.print(f"Total Tools Tested: {total_tools}")
+        self.console.print(f"Total Fuzzing Runs: {total_runs}")
+        self.console.print(f"Total Exceptions: {total_exceptions}")
+        self.console.print(f"Overall Success Rate: {success_rate:.1f}%")
+
+        if vulnerable_tools:
+            self.console.print(
+                f"\n[bold red]Vulnerabilities Found: {len(vulnerable_tools)}[/bold red]"
+            )
+            for tool_name, failures, total in vulnerable_tools:
+                rate = (failures / total * 100) if total > 0 else 0
+                self.console.print(
+                    f"  • {tool_name}: {failures}/{total} failed runs ({rate:.1f}%)"
+                )
+        else:
+            self.console.print("\n[bold green]No vulnerabilities found[/bold green]")
 
     def print_protocol_summary(
         self,

--- a/mcp_fuzzer/reports/formatters/console.py
+++ b/mcp_fuzzer/reports/formatters/console.py
@@ -58,31 +58,33 @@ class ConsoleFormatter:
 
         total_tools = len(results)
         total_runs = 0
+        total_successful = 0
         total_exceptions = 0
-        total_failures = 0
+        total_safety_blocked = 0
         vulnerable_tools: list[tuple[str, int, int]] = []
 
         for tool_name, tool_results in results.items():
             runs, _ = extract_tool_runs(tool_results)
             stats = summarize_tool_runs(runs)
             total_runs += int(stats["total_runs"])
+            total_successful += int(stats["successful"])
             total_exceptions += int(stats["exceptions"])
-            total_failures += int(stats["failures"])
-            if stats["failures"] > 0:
+            total_safety_blocked += int(stats["safety_blocked"])
+            server_failures = max(
+                0, int(stats["failures"]) - int(stats["safety_blocked"])
+            )
+            if server_failures > 0:
                 vulnerable_tools.append(
-                    (tool_name, int(stats["failures"]), int(stats["total_runs"]))
+                    (tool_name, server_failures, int(stats["total_runs"]))
                 )
 
-        success_rate = (
-            ((total_runs - total_failures) / total_runs * 100)
-            if total_runs > 0
-            else 0
-        )
+        success_rate = (total_successful / total_runs * 100) if total_runs > 0 else 0
 
         self.console.print("\n[bold]Tool Execution Statistics[/bold]")
         self.console.print(f"Total Tools Tested: {total_tools}")
         self.console.print(f"Total Fuzzing Runs: {total_runs}")
         self.console.print(f"Total Exceptions: {total_exceptions}")
+        self.console.print(f"Total Safety Blocked: {total_safety_blocked}")
         self.console.print(f"Overall Success Rate: {success_rate:.1f}%")
 
         if vulnerable_tools:
@@ -144,6 +146,7 @@ class ConsoleFormatter:
             self._print_protocol_item_summary(
                 "MCP Prompt Item Fuzzing Summary", "Prompt", prompt_summary
             )
+
     def _print_protocol_item_summary(
         self, title: str, name_header: str, summary: dict[str, dict[str, Any]]
     ) -> None:

--- a/mcp_fuzzer/reports/formatters/json_fmt.py
+++ b/mcp_fuzzer/reports/formatters/json_fmt.py
@@ -6,11 +6,11 @@ from typing import Any
 
 from .common import (
     calculate_protocol_success_rate,
-    calculate_tool_success_rate,
     collect_and_summarize_protocol_items,
     extract_tool_runs,
     normalize_report_data,
     result_has_failure,
+    summarize_tool_runs,
 )
 from ...protocol_types import GET_PROMPT_REQUEST, READ_RESOURCE_REQUEST
 
@@ -52,18 +52,13 @@ class JSONFormatter:
         summary = {}
         for tool_name, tool_results in results.items():
             runs, _ = extract_tool_runs(tool_results)
-            total_runs = len(runs)
-            exceptions = sum(1 for r in runs if "exception" in r)
-            safety_blocked = sum(1 for r in runs if r.get("safety_blocked", False))
-            success_rate = calculate_tool_success_rate(
-                total_runs, exceptions, safety_blocked
-            )
+            stats = summarize_tool_runs(runs)
 
             summary[tool_name] = {
-                "total_runs": total_runs,
-                "exceptions": exceptions,
-                "safety_blocked": safety_blocked,
-                "success_rate": round(success_rate, 2),
+                "total_runs": stats["total_runs"],
+                "exceptions": stats["exceptions"],
+                "safety_blocked": stats["safety_blocked"],
+                "success_rate": round(float(stats["success_rate"]), 2),
             }
 
         return summary

--- a/mcp_fuzzer/reports/formatters/text_fmt.py
+++ b/mcp_fuzzer/reports/formatters/text_fmt.py
@@ -6,9 +6,9 @@ from typing import Any
 
 from .common import (
     calculate_protocol_success_rate,
-    calculate_tool_success_rate,
     extract_tool_runs,
     normalize_report_data,
+    summarize_tool_runs,
 )
 
 
@@ -106,21 +106,14 @@ class TextFormatter:
                 f.write("-" * 40 + "\n")
                 for tool_name, results in data["tool_results"].items():
                     runs, _ = extract_tool_runs(results)
+                    stats = summarize_tool_runs(runs)
                     f.write(f"\nTool: {tool_name}\n")
-                    f.write(f"  Total Runs: {len(runs)}\n")
-
-                    exceptions = sum(1 for r in runs if "exception" in r)
-                    safety_blocked = sum(
-                        1 for r in runs if r.get("safety_blocked", False)
-                    )
-                    f.write(f"  Exceptions: {exceptions}\n")
-                    f.write(f"  Safety Blocked: {safety_blocked}\n")
+                    f.write(f"  Total Runs: {stats['total_runs']}\n")
+                    f.write(f"  Exceptions: {stats['exceptions']}\n")
+                    f.write(f"  Safety Blocked: {stats['safety_blocked']}\n")
 
                     if runs:
-                        success_rate = calculate_tool_success_rate(
-                            len(runs), exceptions, safety_blocked
-                        )
-                        f.write(f"  Success Rate: {success_rate:.1f}%\n")
+                        f.write(f"  Success Rate: {stats['success_rate']:.1f}%\n")
 
             if "protocol_results" in data:
                 f.write("\n\nPROTOCOL FUZZING RESULTS\n")

--- a/mcp_fuzzer/reports/formatters/text_fmt.py
+++ b/mcp_fuzzer/reports/formatters/text_fmt.py
@@ -113,7 +113,9 @@ class TextFormatter:
                     f.write(f"  Safety Blocked: {stats['safety_blocked']}\n")
 
                     if runs:
-                        f.write(f"  Success Rate: {stats['success_rate']:.1f}%\n")
+                        f.write(
+                            f"  Success Rate: {float(stats['success_rate']):.1f}%\n"
+                        )
 
             if "protocol_results" in data:
                 f.write("\n\nPROTOCOL FUZZING RESULTS\n")

--- a/mcp_fuzzer/reports/output/protocol.py
+++ b/mcp_fuzzer/reports/output/protocol.py
@@ -15,7 +15,9 @@ from importlib.metadata import PackageNotFoundError, version
 from ...exceptions import ValidationError
 from ..core import ReportSnapshot
 from ..formatters.common import (
+    calculate_protocol_success_rate,
     extract_tool_runs,
+    result_has_failure,
     summarize_tool_runs,
     tool_run_has_exception,
 )
@@ -24,25 +26,6 @@ try:
     TOOL_VERSION = version("mcp-fuzzer")
 except PackageNotFoundError:
     TOOL_VERSION = "unknown"
-
-
-def _result_has_failure(result: dict[str, Any]) -> bool:
-    """Return True when a result indicates a failure."""
-    return bool(
-        result.get("exception")
-        or not result.get("success", True)
-        or result.get("error")
-        or result.get("server_error")
-    )
-
-
-def _rate(total: int, failures: int) -> float:
-    if total <= 0:
-        return 0.0
-    successes = max(total - failures, 0)
-    return (successes / total) * 100
-
-
 class OutputProtocol:
     """Handles standardized output format with mini-protocol for MCP Fuzzer."""
 
@@ -307,9 +290,9 @@ class OutputProtocol:
         formatted = []
         for protocol_type, results in protocol_results.items():
             total_runs = len(results)
-            errors = sum(1 for r in results if _result_has_failure(r))
+            errors = sum(1 for r in results if result_has_failure(r))
             successes = max(total_runs - errors, 0)
-            success_rate = _rate(total_runs, errors)
+            success_rate = calculate_protocol_success_rate(total_runs, errors)
             formatted.append(
                 {
                     "type": protocol_type,

--- a/mcp_fuzzer/reports/output/protocol.py
+++ b/mcp_fuzzer/reports/output/protocol.py
@@ -14,7 +14,11 @@ from importlib.metadata import PackageNotFoundError, version
 
 from ...exceptions import ValidationError
 from ..core import ReportSnapshot
-from ..formatters.common import extract_tool_runs
+from ..formatters.common import (
+    extract_tool_runs,
+    summarize_tool_runs,
+    tool_run_has_exception,
+)
 
 try:
     TOOL_VERSION = version("mcp-fuzzer")
@@ -270,19 +274,15 @@ class OutputProtocol:
         formatted = []
         for tool_name, results in tool_results.items():
             runs, _ = extract_tool_runs(results)
-            total_runs = len(runs)
-            exceptions = sum(1 for r in runs if "exception" in r)
-            safety_blocked = sum(1 for r in runs if r.get("safety_blocked", False))
-            successful = max(total_runs - exceptions - safety_blocked, 0)
-            success_rate = _rate(total_runs, exceptions + safety_blocked)
+            stats = summarize_tool_runs(runs)
             formatted.append(
                 {
                     "name": tool_name,
-                    "runs": total_runs,
-                    "successful": successful,
-                    "exceptions": exceptions,
-                    "safety_blocked": safety_blocked,
-                    "success_rate": success_rate,
+                    "runs": stats["total_runs"],
+                    "successful": stats["successful"],
+                    "exceptions": stats["exceptions"],
+                    "safety_blocked": stats["safety_blocked"],
+                    "success_rate": stats["success_rate"],
                     "exception_details": [
                         {
                             "type": (
@@ -294,7 +294,7 @@ class OutputProtocol:
                             "arguments": r.get("args", {}),
                         }
                         for r in runs
-                        if "exception" in r
+                        if tool_run_has_exception(r)
                     ],
                 }
             )

--- a/mcp_fuzzer/reports/reporter/__init__.py
+++ b/mcp_fuzzer/reports/reporter/__init__.py
@@ -207,6 +207,13 @@ class FuzzerReporter:
             runs, _ = extract_tool_runs(tool_results)
             self.add_tool_results(tool_name, runs)
 
+    def print_tool_execution_summary(self, results: dict[str, Any]) -> None:
+        """Print tool summary plus aggregate run statistics."""
+        self.console_formatter.print_tool_execution_summary(results)
+        for tool_name, tool_results in results.items():
+            runs, _ = extract_tool_runs(tool_results)
+            self.add_tool_results(tool_name, runs)
+
     def print_protocol_summary(
         self,
         results: dict[str, list[dict[str, Any]]],
@@ -245,6 +252,10 @@ class FuzzerReporter:
     def print_safety_summary(self):
         """Print safety system summary to console."""
         self.safety_reporter.print_safety_summary()
+
+    def print_safety_system_summary(self):
+        """Print safety-system blocked operation details."""
+        self.safety_reporter.print_safety_system_summary()
 
     def print_comprehensive_safety_report(self):
         """Print comprehensive safety report to console."""
@@ -375,6 +386,22 @@ class FuzzerReporter:
         return self.formatter_registry.save(
             format_name, snapshot, self.output_dir, filename
         )
+
+    async def export_requested_formats(
+        self,
+        export_targets: Mapping[str, str],
+        *,
+        include_safety: bool = False,
+    ) -> dict[str, str]:
+        """Export all requested named formats and return written file names."""
+        exported: dict[str, str] = {}
+        for format_name, filename in export_targets.items():
+            exported[format_name] = await self.export_format(
+                format_name,
+                filename,
+                include_safety=include_safety,
+            )
+        return exported
 
     async def _prepare_snapshot(
         self, include_safety: bool, finalize: bool

--- a/mcp_fuzzer/reports/reporter/__init__.py
+++ b/mcp_fuzzer/reports/reporter/__init__.py
@@ -30,6 +30,7 @@ from ..formatters.common import extract_tool_runs
 from ..output import OutputManager
 from .config import ReporterConfig
 from ..safety_reporter import SafetyReporter
+from ...safety_system.safety import CombinedSafetyProvider
 
 from importlib.metadata import version, PackageNotFoundError
 
@@ -51,7 +52,7 @@ class FuzzerReporter:
         output_dir: str = "reports",
         compress_output: bool = False,
         config_provider: Mapping[str, Any] | None = None,
-        safety_system=_AUTO_FILTER,
+        safety_system: CombinedSafetyProvider | object = _AUTO_FILTER,
         collector: ReportCollector | None = None,
         output_manager: OutputManager | None = None,
         console: Console | None = None,
@@ -132,7 +133,7 @@ class FuzzerReporter:
     @staticmethod
     def _resolve_safety_reporter(
         safety_reporter: SafetyReporter | None,
-        safety_system: Any,
+        safety_system: CombinedSafetyProvider | object,
     ) -> SafetyReporter:
         if safety_reporter is not None:
             return safety_reporter

--- a/mcp_fuzzer/reports/reporter/__init__.py
+++ b/mcp_fuzzer/reports/reporter/__init__.py
@@ -396,11 +396,19 @@ class FuzzerReporter:
         """Export all requested named formats and return written file names."""
         exported: dict[str, str] = {}
         for format_name, filename in export_targets.items():
-            exported[format_name] = await self.export_format(
-                format_name,
-                filename,
-                include_safety=include_safety,
-            )
+            try:
+                exported[format_name] = await self.export_format(
+                    format_name,
+                    filename,
+                    include_safety=include_safety,
+                )
+            except Exception as exc:
+                logging.error(
+                    "Failed to export %s report to %s: %s",
+                    format_name,
+                    filename,
+                    exc,
+                )
         return exported
 
     async def _prepare_snapshot(

--- a/mcp_fuzzer/types.py
+++ b/mcp_fuzzer/types.py
@@ -1,15 +1,64 @@
 #!/usr/bin/env python3
-"""
-Common type definitions for MCP Fuzzer
+"""Common typed contracts shared across the MCP Fuzzer codebase."""
 
-This module provides TypedDict definitions and other type structures
-to improve type safety throughout the codebase.
-"""
+from __future__ import annotations
 
-from typing import Any, TypedDict
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, NamedTuple, Protocol, TypedDict, runtime_checkable
 
 # JSON container types
 JSONContainer = dict[str, Any] | list[Any]
+SpecCheck = dict[str, Any]
+
+
+class StringValueEnum(str, Enum):
+    """Enum that preserves its raw string value in logs and JSON output."""
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+
+class ErrorType(StringValueEnum):
+    """Canonical error identifiers used in tool fuzzing result payloads."""
+
+    PHASE_EXECUTION_FAILED = "phase_execution_failed"
+    SAFETY_BLOCKED = "safety_blocked"
+    TOOL_CALL_FAILED = "tool_call_failed"
+    TOOL_MUTATION_FAILED = "tool_mutation_failed"
+    TOOL_TIMEOUT = "tool_timeout"
+
+
+class TimeoutScope(StringValueEnum):
+    """Scope of a timeout reported in a tool run."""
+
+    CALL = "call"
+    SESSION = "session"
+
+
+@runtime_checkable
+class AuthManagerProtocol(Protocol):
+    """Minimal auth-manager behavior required by runtime clients."""
+
+    def get_auth_headers_for_tool(self, tool_name: str) -> dict[str, str]: ...
+    def get_auth_params_for_tool(self, tool_name: str) -> dict[str, Any]: ...
+    def get_default_auth_headers(self) -> dict[str, str]: ...
+
+
+@dataclass(frozen=True)
+class ProtocolSpec:
+    """Declarative protocol dispatch metadata."""
+
+    handler_name: str
+    method: str
+    is_notification: bool
+
+
+class ExtractedToolRuns(NamedTuple):
+    """Structured tool-run extraction result that still supports unpacking."""
+
+    runs: list["ToolRunResult"]
+    metadata: Mapping[str, Any] | None
 
 
 class FuzzDataResult(TypedDict, total=False):
@@ -34,7 +83,7 @@ class ProtocolFuzzResult(TypedDict, total=False):
 
     fuzz_data: dict[str, Any]
     result: dict[str, Any]
-    spec_checks: list[dict[str, Any]]
+    spec_checks: list[SpecCheck]
     spec_scope: str
     safety_blocked: bool
     safety_sanitized: bool
@@ -43,19 +92,24 @@ class ProtocolFuzzResult(TypedDict, total=False):
     traceback: str | None
 
 
-class ToolFuzzResult(TypedDict, total=False):
-    """TypedDict for tool fuzzing results."""
+class ToolRunResult(TypedDict, total=False):
+    """TypedDict for a single tool run result."""
 
-    args: dict[str, Any]
-    result: dict[str, Any]
-    spec_checks: list[dict[str, Any]]
+    args: dict[str, Any] | None
+    label: str
+    result: JSONContainer | None
+    spec_checks: list[SpecCheck]
     spec_scope: str
     safety_blocked: bool
     safety_sanitized: bool
     success: bool
     exception: str | None
     traceback: str | None
-    error: str | None
+    error: ErrorType | str | None
+    timeout_scope: TimeoutScope | str | None
+
+
+ToolFuzzResult = ToolRunResult
 
 
 class BatchExecutionResult(TypedDict):

--- a/mcp_fuzzer/version.py
+++ b/mcp_fuzzer/version.py
@@ -1,3 +1,3 @@
-VERSION = "0.3.2"
+VERSION = "0.3.3"
 
 __all__ = ["VERSION"]

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -24,7 +24,10 @@ from mcp_fuzzer.client.runtime.async_runner import AsyncRunner
 from mcp_fuzzer.client.runtime.async_runner import execute_inner_client
 from mcp_fuzzer.client.runtime.retry import run_with_retry_on_interrupt
 from mcp_fuzzer.client.safety import SafetyController
-from mcp_fuzzer.client.transport.factory import build_driver_with_auth
+from mcp_fuzzer.client.transport.factory import (
+    TransportBuildRequest,
+    build_driver_with_auth,
+)
 from mcp_fuzzer.env import ValidationType
 from mcp_fuzzer.exceptions import ArgumentValidationError, ConfigFileError, MCPError
 
@@ -353,11 +356,17 @@ def test_prepare_inner_argv_roundtrip():
 
 
 def test_transport_factory_applies_auth_headers():
-    args = MagicMock(protocol="http", endpoint="http://example.com", timeout=10.0)
-    auth_manager = MagicMock()
-    auth_manager.get_default_auth_headers.return_value = {"Authorization": "x"}
+    request = TransportBuildRequest(
+        protocol="http",
+        endpoint="http://example.com",
+        timeout=10.0,
+        auth_manager=MagicMock(),
+    )
+    request.auth_manager.get_default_auth_headers.return_value = {
+        "Authorization": "x"
+    }
     with patch("mcp_fuzzer.client.transport.factory.base_build_driver") as mock_create:
-        build_driver_with_auth(args, {"auth_manager": auth_manager})
+        build_driver_with_auth(request)
         mock_create.assert_called_once_with(
             "http",
             "http://example.com",

--- a/tests/unit/client/test_client.py
+++ b/tests/unit/client/test_client.py
@@ -737,7 +737,7 @@ class TestUnifiedMCPFuzzerClient:
 
         # Verify tool_client.fuzz_all_tools_both_phases was called
         self.mock_tool_client.fuzz_all_tools_both_phases.assert_called_once_with(
-            runs_per_phase=1
+            runs_per_phase=1, tool_timeout=None
         )
 
     @pytest.mark.asyncio
@@ -755,7 +755,7 @@ class TestUnifiedMCPFuzzerClient:
 
         # Verify tool_client.fuzz_all_tools_both_phases was called
         self.mock_tool_client.fuzz_all_tools_both_phases.assert_called_once_with(
-            runs_per_phase=5
+            runs_per_phase=5, tool_timeout=None
         )
 
     @pytest.mark.asyncio
@@ -1723,7 +1723,28 @@ class TestUnifiedMCPFuzzerClient:
 
         # Verify tool_client.fuzz_tool_both_phases was called
         self.mock_tool_client.fuzz_tool_both_phases.assert_called_once_with(
-            tool, runs_per_phase=1
+            tool, runs_per_phase=1, tool_timeout=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_fuzz_tool_both_phases_forwards_explicit_timeout(self):
+        """Test explicit timeout propagation for two-phase single-tool fuzzing."""
+        tool = {"name": "test_tool"}
+        self.mock_tool_client.fuzz_tool_both_phases.return_value = {
+            "realistic": [],
+            "aggressive": [],
+        }
+
+        await self.client.fuzz_tool_both_phases(
+            tool,
+            runs_per_phase=1,
+            tool_timeout=0.05,
+        )
+
+        self.mock_tool_client.fuzz_tool_both_phases.assert_called_once_with(
+            tool,
+            runs_per_phase=1,
+            tool_timeout=0.05,
         )
 
     @pytest.mark.asyncio
@@ -1938,7 +1959,22 @@ class TestUnifiedMCPFuzzerClient:
 
         # Verify tool_client.fuzz_all_tools_both_phases was called
         self.mock_tool_client.fuzz_all_tools_both_phases.assert_called_once_with(
-            runs_per_phase=1
+            runs_per_phase=1, tool_timeout=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_fuzz_all_tools_both_phases_forwards_explicit_timeout(self):
+        """Test explicit timeout propagation for two-phase all-tools fuzzing."""
+        self.mock_tool_client.fuzz_all_tools_both_phases.return_value = {}
+
+        await self.client.fuzz_all_tools_both_phases(
+            runs_per_phase=1,
+            tool_timeout=0.05,
+        )
+
+        self.mock_tool_client.fuzz_all_tools_both_phases.assert_called_once_with(
+            runs_per_phase=1,
+            tool_timeout=0.05,
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/client/test_client_main.py
+++ b/tests/unit/client/test_client_main.py
@@ -39,6 +39,9 @@ def _settings(**overrides):
 def _make_reporter():
     reporter = MagicMock()
     reporter.export_format = AsyncMock()
+    reporter.generate_standardized_report = AsyncMock(return_value={})
+    reporter.export_requested_formats = AsyncMock(return_value={})
+    reporter.set_fuzzing_metadata = MagicMock()
     return reporter
 
 
@@ -46,13 +49,13 @@ def test_unified_client_main_tools_mode():
     settings = _settings()
     mock_transport = MagicMock()
     mock_safety = MagicMock()
-    mock_reporter = MagicMock()
+    mock_reporter = _make_reporter()
     client_instance = MagicMock()
     client_instance.fuzz_all_tools = AsyncMock(
         return_value={"tool1": [{"result": "ok"}]}
     )
-    client_instance.generate_standardized_reports = AsyncMock(return_value={})
     client_instance.cleanup = AsyncMock()
+    client_instance.reporter = mock_reporter
 
     with (
         patch(
@@ -69,13 +72,17 @@ def test_unified_client_main_tools_mode():
     mock_transport_factory.assert_called_once()
     assert client_instance.fuzz_all_tools.await_count == 1
     client_instance.cleanup.assert_awaited()
-    mock_reporter.export_format.assert_not_called()
+    mock_reporter.export_requested_formats.assert_awaited_once_with(
+        {},
+        include_safety=False,
+    )
 
 
 def test_unified_client_main_unknown_mode_logs_error_and_returns_nonzero():
     settings = _settings(mode="unknown")
     client_instance = MagicMock()
     client_instance.cleanup = AsyncMock()
+    client_instance.reporter = _make_reporter()
     with (
         patch(
             "mcp_fuzzer.client.main.build_driver_with_auth",
@@ -95,8 +102,8 @@ def test_unified_client_main_sets_fs_root_when_provided():
     mock_safety = MagicMock()
     client_instance = MagicMock()
     client_instance.fuzz_all_tools = AsyncMock(return_value={})
-    client_instance.generate_standardized_reports = AsyncMock(return_value={})
     client_instance.cleanup = AsyncMock()
+    client_instance.reporter = _make_reporter()
 
     with (
         patch(
@@ -119,6 +126,7 @@ def test_unified_client_main_protocol_and_both_modes():
     client_instance.fuzz_all_protocol_types = AsyncMock()
     client_instance.run_spec_suite = AsyncMock(return_value=[])
     client_instance.cleanup = AsyncMock()
+    client_instance.reporter = _make_reporter()
     with (
         patch(
             "mcp_fuzzer.client.main.build_driver_with_auth",
@@ -139,6 +147,7 @@ def test_unified_client_main_protocol_and_both_modes():
     client_instance2.fuzz_protocol_type = AsyncMock()
     client_instance2.run_spec_suite = AsyncMock(return_value=[])
     client_instance2.cleanup = AsyncMock()
+    client_instance2.reporter = _make_reporter()
     with (
         patch(
             "mcp_fuzzer.client.main.build_driver_with_auth",
@@ -163,7 +172,6 @@ def test_unified_client_main_exports_reports_and_handles_errors():
     )
     client_instance = MagicMock()
     client_instance.fuzz_tool = AsyncMock(return_value={})
-    client_instance.generate_standardized_reports = AsyncMock(return_value={"f": "p"})
     client_instance.cleanup = AsyncMock()
     reporter = _make_reporter()
     client_instance.reporter = reporter
@@ -177,8 +185,10 @@ def test_unified_client_main_exports_reports_and_handles_errors():
         patch("mcp_fuzzer.client.main.MCPFuzzerClient", return_value=client_instance),
     ):
         asyncio.run(unified_client_main(settings))
-    reporter.export_format.assert_any_call("csv", "out.csv")
-    reporter.export_format.assert_any_call("markdown", "md.md")
+    reporter.export_requested_formats.assert_awaited_once_with(
+        {"csv": "out.csv", "markdown": "md.md"},
+        include_safety=False,
+    )
 
 
 def test_unified_client_main_exports_html_xml():
@@ -190,7 +200,6 @@ def test_unified_client_main_exports_html_xml():
     )
     client_instance = MagicMock()
     client_instance.fuzz_tool = AsyncMock(return_value={})
-    client_instance.generate_standardized_reports = AsyncMock(return_value={})
     client_instance.cleanup = AsyncMock()
     reporter = _make_reporter()
     client_instance.reporter = reporter
@@ -204,16 +213,18 @@ def test_unified_client_main_exports_html_xml():
         patch("mcp_fuzzer.client.main.MCPFuzzerClient", return_value=client_instance),
     ):
         asyncio.run(unified_client_main(settings))
-    reporter.export_format.assert_any_call("html", "out.html")
-    reporter.export_format.assert_any_call("xml", "out.xml")
+    reporter.export_requested_formats.assert_awaited_once_with(
+        {"html": "out.html", "xml": "out.xml"},
+        include_safety=False,
+    )
 
 
 def test_unified_client_main_safety_disabled():
     settings = _settings(safety_enabled=False)
     client_instance = MagicMock()
     client_instance.fuzz_all_tools = AsyncMock(return_value={})
-    client_instance.generate_standardized_reports = AsyncMock(return_value={})
     client_instance.cleanup = AsyncMock()
+    client_instance.reporter = _make_reporter()
     with (
         patch(
             "mcp_fuzzer.client.main.build_driver_with_auth",
@@ -230,12 +241,12 @@ def test_unified_client_main_safety_disabled():
 def test_unified_client_main_tool_results_summary(monkeypatch):
     settings = _settings(mode="tools")
     client_instance = MagicMock()
+    reporter = _make_reporter()
     client_instance.fuzz_all_tools = AsyncMock(
         return_value={"tool1": [{"exception": None}, {"exception": {"err": 1}}]}
     )
-    client_instance.generate_standardized_reports = AsyncMock(return_value={})
     client_instance.cleanup = AsyncMock()
-    client_instance.print_tool_summary = MagicMock()
+    client_instance.reporter = reporter
     with (
         patch(
             "mcp_fuzzer.client.main.build_driver_with_auth",
@@ -247,7 +258,7 @@ def test_unified_client_main_tool_results_summary(monkeypatch):
         patch("builtins.print"),
     ):
         asyncio.run(unified_client_main(settings))
-    client_instance.print_tool_summary.assert_called_once()
+    reporter.print_tool_execution_summary.assert_called_once()
 
 
 def test_unified_client_main_returns_one_on_exception():
@@ -255,6 +266,7 @@ def test_unified_client_main_returns_one_on_exception():
     client_instance = MagicMock()
     client_instance.fuzz_all_tools = AsyncMock(side_effect=Exception("boom"))
     client_instance.cleanup = AsyncMock()
+    client_instance.reporter = _make_reporter()
     with (
         patch(
             "mcp_fuzzer.client.main.build_driver_with_auth",
@@ -270,7 +282,7 @@ def test_unified_client_main_returns_one_on_exception():
 
 class StubClient:
     def __init__(self, **_kwargs):
-        self.reporter = None
+        self.reporter = _make_reporter()
         self._spec_checks = []
 
     async def fuzz_tool_both_phases(self, *_args, **_kwargs):
@@ -302,15 +314,6 @@ class StubClient:
 
     async def cleanup(self):
         return None
-
-    def print_protocol_summary(self, *_args, **_kwargs):
-        return None
-
-    def print_tool_summary(self, *_args, **_kwargs):
-        return None
-
-    async def generate_standardized_reports(self, *_args, **_kwargs):
-        return {}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/client/test_protocol_client.py
+++ b/tests/unit/client/test_protocol_client.py
@@ -236,6 +236,20 @@ async def test_fuzz_protocol_type_appends_listed_prompts():
     client._fuzz_listed_prompts.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_fetch_listed_tools_remembers_tools():
+    transport = MagicMock()
+    transport.send_request = AsyncMock(
+        return_value={"result": {"tools": [{"name": "alpha"}]}}
+    )
+    client = ProtocolClient(transport=transport, safety_system=None)
+
+    tools = await client._fetch_listed_tools()
+
+    assert tools == [{"name": "alpha"}]
+    assert "alpha" in client._observed_tools
+
+
 def test_extract_params_handles_non_dict():
     client = ProtocolClient(transport=MagicMock(), safety_system=None)
 

--- a/tests/unit/client/test_protocol_client.py
+++ b/tests/unit/client/test_protocol_client.py
@@ -157,7 +157,7 @@ async def test_process_single_protocol_fuzz_mutator_none():
 @pytest.mark.asyncio
 async def test_fuzz_all_protocol_types_empty_list():
     client = ProtocolClient(transport=MagicMock(), safety_system=None)
-    client._get_protocol_types = AsyncMock(return_value=[])
+    client._get_protocol_types = MagicMock(return_value=[])
 
     result = await client.fuzz_all_protocol_types()
 
@@ -167,7 +167,7 @@ async def test_fuzz_all_protocol_types_empty_list():
 @pytest.mark.asyncio
 async def test_fuzz_all_protocol_types_runs():
     client = ProtocolClient(transport=MagicMock(), safety_system=None)
-    client._get_protocol_types = AsyncMock(return_value=["InitializeRequest"])
+    client._get_protocol_types = MagicMock(return_value=["InitializeRequest"])
     client._process_single_protocol_fuzz = AsyncMock(return_value={"success": True})
 
     result = await client.fuzz_all_protocol_types(runs_per_type=2)
@@ -178,7 +178,7 @@ async def test_fuzz_all_protocol_types_runs():
 @pytest.mark.asyncio
 async def test_fuzz_all_protocol_types_appends_listed_results():
     client = ProtocolClient(transport=MagicMock(), safety_system=None)
-    client._get_protocol_types = AsyncMock(
+    client._get_protocol_types = MagicMock(
         return_value=["ReadResourceRequest", "GetPromptRequest"]
     )
     client._process_single_protocol_fuzz = AsyncMock(return_value={"success": True})

--- a/tests/unit/client/test_protocol_client_coverage.py
+++ b/tests/unit/client/test_protocol_client_coverage.py
@@ -149,14 +149,13 @@ async def test_send_generic_request_non_string_method(client):
     assert result == {"ok": True}
     client.transport.send_request.assert_called_with("unknown", {"a": 1})
 
-@pytest.mark.asyncio
-async def test_get_protocol_types_reads_supported_protocols():
+def test_get_protocol_types_reads_supported_protocols():
     client = ProtocolClient(transport=MagicMock(), safety_system=None)
     with patch(
         "mcp_fuzzer.client.protocol_client.SUPPORTED_PROTOCOL_TYPES",
         ("PingRequest",),
     ):
-        result = await client._get_protocol_types()
+        result = client._get_protocol_types()
         assert result == ["PingRequest"]
 
 @pytest.mark.asyncio

--- a/tests/unit/client/test_protocol_client_coverage.py
+++ b/tests/unit/client/test_protocol_client_coverage.py
@@ -150,14 +150,14 @@ async def test_send_generic_request_non_string_method(client):
     client.transport.send_request.assert_called_with("unknown", {"a": 1})
 
 @pytest.mark.asyncio
-async def test_get_protocol_types_exception():
+async def test_get_protocol_types_reads_supported_protocols():
     client = ProtocolClient(transport=MagicMock(), safety_system=None)
     with patch(
-        "mcp_fuzzer.client.protocol_client.ProtocolExecutor",
-        side_effect=Exception("boom"),
+        "mcp_fuzzer.client.protocol_client.SUPPORTED_PROTOCOL_TYPES",
+        ("PingRequest",),
     ):
         result = await client._get_protocol_types()
-        assert result == []
+        assert result == ["PingRequest"]
 
 @pytest.mark.asyncio
 async def test_fuzz_all_protocol_types_exception():

--- a/tests/unit/client/test_protocol_client_coverage.py
+++ b/tests/unit/client/test_protocol_client_coverage.py
@@ -161,7 +161,7 @@ def test_get_protocol_types_reads_supported_protocols():
 @pytest.mark.asyncio
 async def test_fuzz_all_protocol_types_exception():
     client = ProtocolClient(transport=MagicMock(), safety_system=None)
-    client._get_protocol_types = AsyncMock(side_effect=Exception("boom"))
+    client._get_protocol_types = MagicMock(side_effect=Exception("boom"))
     result = await client.fuzz_all_protocol_types()
     assert result == {}
 

--- a/tests/unit/client/test_protocol_client_extended.py
+++ b/tests/unit/client/test_protocol_client_extended.py
@@ -204,31 +204,11 @@ class TestGetProtocolTypes:
     async def test_get_protocol_types_returns_list(self, client):
         """Test getting protocol types returns a list."""
         with patch(
-            "mcp_fuzzer.client.protocol_client.ProtocolExecutor"
-        ) as mock_executor:
-            mock_executor.PROTOCOL_TYPES = ["InitializeRequest", "ListResourcesRequest"]
-            result = await client._get_protocol_types()
-            assert result == ["InitializeRequest", "ListResourcesRequest"]
-
-    @pytest.mark.asyncio
-    async def test_get_protocol_types_handles_missing_attr(self, client):
-        """Test getting protocol types handles missing attribute."""
-        with patch(
-            "mcp_fuzzer.client.protocol_client.ProtocolExecutor"
-        ) as mock_executor:
-            del mock_executor.PROTOCOL_TYPES
-            result = await client._get_protocol_types()
-            assert result == []
-
-    @pytest.mark.asyncio
-    async def test_get_protocol_types_handles_exception(self, client):
-        """Test getting protocol types handles exceptions."""
-        with patch(
-            "mcp_fuzzer.client.protocol_client.ProtocolExecutor",
-            side_effect=Exception("fail"),
+            "mcp_fuzzer.client.protocol_client.SUPPORTED_PROTOCOL_TYPES",
+            ("InitializeRequest", "ListResourcesRequest"),
         ):
             result = await client._get_protocol_types()
-            assert result == []
+            assert result == ["InitializeRequest", "ListResourcesRequest"]
 
 
 class TestFuzzAllProtocolTypes:

--- a/tests/unit/client/test_protocol_client_extended.py
+++ b/tests/unit/client/test_protocol_client_extended.py
@@ -2,7 +2,9 @@
 
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
-from mcp_fuzzer.client.protocol_client import ProtocolClient
+
+from mcp_fuzzer.client.protocol_client import ProtocolClient, SUPPORTED_PROTOCOL_TYPES
+from mcp_fuzzer.protocol_registry import EXECUTABLE_PROTOCOL_TYPES
 
 
 @pytest.fixture
@@ -200,15 +202,18 @@ class TestProtocolRequestDispatch:
 class TestGetProtocolTypes:
     """Test _get_protocol_types method."""
 
-    @pytest.mark.asyncio
-    async def test_get_protocol_types_returns_list(self, client):
+    def test_get_protocol_types_returns_list(self, client):
         """Test getting protocol types returns a list."""
         with patch(
             "mcp_fuzzer.client.protocol_client.SUPPORTED_PROTOCOL_TYPES",
             ("InitializeRequest", "ListResourcesRequest"),
         ):
-            result = await client._get_protocol_types()
+            result = client._get_protocol_types()
             assert result == ["InitializeRequest", "ListResourcesRequest"]
+
+    def test_supported_protocol_types_match_registry_order(self):
+        """ProtocolClient should stay aligned with executable registry types."""
+        assert SUPPORTED_PROTOCOL_TYPES == tuple(EXECUTABLE_PROTOCOL_TYPES)
 
 
 class TestFuzzAllProtocolTypes:
@@ -217,21 +222,21 @@ class TestFuzzAllProtocolTypes:
     @pytest.mark.asyncio
     async def test_fuzz_all_returns_empty_when_no_types(self, client):
         """Test fuzzing all types returns empty when no protocol types."""
-        client._get_protocol_types = AsyncMock(return_value=[])
+        client._get_protocol_types = MagicMock(return_value=[])
         result = await client.fuzz_all_protocol_types()
         assert result == {}
 
     @pytest.mark.asyncio
     async def test_fuzz_all_handles_exception(self, client):
         """Test fuzzing all types handles exceptions gracefully."""
-        client._get_protocol_types = AsyncMock(side_effect=Exception("boom"))
+        client._get_protocol_types = MagicMock(side_effect=Exception("boom"))
         result = await client.fuzz_all_protocol_types()
         assert result == {}
 
     @pytest.mark.asyncio
     async def test_fuzz_all_runs_for_each_type(self, client):
         """Test fuzzing all types runs for each protocol type."""
-        client._get_protocol_types = AsyncMock(return_value=["InitializeRequest"])
+        client._get_protocol_types = MagicMock(return_value=["InitializeRequest"])
         client._process_single_protocol_fuzz = AsyncMock(
             return_value={"success": True}
         )

--- a/tests/unit/client/test_tool_client.py
+++ b/tests/unit/client/test_tool_client.py
@@ -129,6 +129,7 @@ async def test_fuzz_single_tool_with_timeout_returns_timeout_error():
         results = await client._fuzz_single_tool_with_timeout(tool, runs_per_tool=1)
 
     assert results[0]["error"] == "tool_timeout"
+    assert results[0]["timeout_scope"] == "session"
 
 
 @pytest.mark.asyncio
@@ -186,3 +187,34 @@ async def test_fuzz_tool_both_phases_runs():
 
     assert result["realistic"] == [{"ok": True}]
     assert result["aggressive"] == [{"ok": False}]
+
+
+@pytest.mark.asyncio
+async def test_fuzz_tool_applies_per_call_timeout():
+    safety = MagicMock()
+    safety.should_skip_tool_call.return_value = False
+    safety.sanitize_tool_arguments.side_effect = lambda _name, args: args
+    client = ToolClient(
+        MagicMock(),
+        auth_manager=MagicMock(),
+        safety_system=safety,
+    )
+    client.tool_mutator.mutate = AsyncMock(return_value={"x": 1})
+
+    async def _slow_call(*_args, **_kwargs):
+        await asyncio.sleep(0.05)
+        return {"ok": True}
+
+    client._rpc = MagicMock()
+    client._rpc.call_tool = _slow_call
+
+    results = await client.fuzz_tool(
+        {"name": "alpha"},
+        runs=1,
+        tool_timeout=0.01,
+    )
+
+    assert results[0]["success"] is False
+    assert results[0]["error"] == "tool_timeout"
+    assert results[0]["timeout_scope"] == "call"
+    assert "timed out" in results[0]["exception"]

--- a/tests/unit/client/test_tool_client.py
+++ b/tests/unit/client/test_tool_client.py
@@ -52,7 +52,8 @@ async def test_fuzz_tool_safety_blocked():
     results = await client.fuzz_tool({"name": "alpha"}, runs=1)
 
     assert results[0]["safety_blocked"] is True
-    assert results[0]["exception"] == "safety_blocked"
+    assert results[0]["error"] == "safety_blocked"
+    assert "exception" not in results[0]
     client._rpc.call_tool.assert_not_called()
 
 
@@ -141,7 +142,7 @@ async def test_process_fuzz_results_safety_blocked():
 
     results = await client._process_fuzz_results("alpha", [{"args": {"x": 1}}])
 
-    assert results[0]["exception"] == "safety_blocked"
+    assert results[0]["error"] == "safety_blocked"
     assert results[0]["safety_blocked"] is True
 
 

--- a/tests/unit/client/test_tool_client.py
+++ b/tests/unit/client/test_tool_client.py
@@ -190,6 +190,34 @@ async def test_fuzz_tool_both_phases_runs():
 
 
 @pytest.mark.asyncio
+async def test_fuzz_tool_both_phases_forwards_tool_timeout():
+    client = ToolClient(
+        MagicMock(),
+        auth_manager=MagicMock(),
+        safety_system=MagicMock(),
+    )
+    client.tool_mutator.mutate = AsyncMock(side_effect=[{"a": 1}, {"b": 2}])
+    client._process_fuzz_results = AsyncMock(
+        side_effect=[[{"ok": True}], [{"ok": False}]]
+    )
+
+    await client.fuzz_tool_both_phases(
+        {"name": "alpha"},
+        runs_per_phase=1,
+        tool_timeout=0.25,
+    )
+
+    first_timeout = client._process_fuzz_results.await_args_list[0].kwargs[
+        "tool_timeout"
+    ]
+    second_timeout = client._process_fuzz_results.await_args_list[1].kwargs[
+        "tool_timeout"
+    ]
+    assert first_timeout == 0.25
+    assert second_timeout == 0.25
+
+
+@pytest.mark.asyncio
 async def test_fuzz_tool_applies_per_call_timeout():
     safety = MagicMock()
     safety.should_skip_tool_call.return_value = False

--- a/tests/unit/client/test_tool_client_extended.py
+++ b/tests/unit/client/test_tool_client_extended.py
@@ -109,7 +109,8 @@ class TestFuzzTool:
         
         assert len(results) == 1
         assert results[0]["safety_blocked"] is True
-        assert results[0]["exception"] == "safety_blocked"
+        assert results[0]["error"] == "safety_blocked"
+        assert "exception" not in results[0]
 
     @pytest.mark.asyncio
     async def test_fuzz_tool_safety_sanitized(self, tool_client, mock_safety):
@@ -280,6 +281,7 @@ class TestFuzzToolBothPhases:
         
         assert "error" in results
         assert "mutator error" in results["error"]
+        assert results["runs"][0]["error"] == "phase_execution_failed"
 
 
 class TestProcessFuzzResults:
@@ -418,6 +420,7 @@ class TestFuzzSingleToolBothPhases:
         result = await tool_client._fuzz_single_tool_both_phases(tool, 2)
         
         assert "error" in result
+        assert result["error"] == "some error"
 
     @pytest.mark.asyncio
     async def test_single_tool_both_phases_exception(self, tool_client):
@@ -429,6 +432,7 @@ class TestFuzzSingleToolBothPhases:
         
         assert "error" in result
         assert "boom" in result["error"]
+        assert result["runs"][0]["exception"] == "boom"
 
 
 class TestSafetyDisabled:

--- a/tests/unit/reports/test_common.py
+++ b/tests/unit/reports/test_common.py
@@ -13,6 +13,8 @@ from mcp_fuzzer.reports.formatters.common import (
     normalize_report_data,
     result_has_failure,
     summarize_protocol_items,
+    summarize_tool_runs,
+    tool_run_has_exception,
 )
 
 pytestmark = [pytest.mark.unit]
@@ -66,6 +68,13 @@ def test_extract_tool_runs_from_unexpected_value():
     assert metadata is None
 
 
+def test_extract_tool_runs_from_error_only_entry():
+    entry = {"success": False, "error": "phase failed", "exception": "boom"}
+    runs, metadata = extract_tool_runs(entry)
+    assert runs == [{"success": False, "error": "phase failed", "exception": "boom", "safety_blocked": False, "safety_sanitized": False}]
+    assert metadata is entry
+
+
 def test_calculate_protocol_success_rate_handles_zero_runs():
     assert calculate_protocol_success_rate(0, 1) == 0.0
 
@@ -116,3 +125,24 @@ def test_summarize_protocol_items_detects_failures():
     assert summary["alpha"]["errors"] == 1
     assert summary["beta"]["errors"] == 1
     assert result_has_failure({"success": False})
+
+
+def test_tool_run_has_exception_excludes_safety_blocked():
+    assert tool_run_has_exception({"exception": "boom"})
+    assert not tool_run_has_exception(
+        {"exception": "safety_blocked", "safety_blocked": True}
+    )
+
+
+def test_summarize_tool_runs_uses_non_overlapping_failure_counts():
+    summary = summarize_tool_runs(
+        [
+            {"success": True},
+            {"exception": "boom"},
+            {"success": False, "safety_blocked": True},
+        ]
+    )
+    assert summary["exceptions"] == 1
+    assert summary["safety_blocked"] == 1
+    assert summary["successful"] == 1
+    assert summary["success_rate"] == pytest.approx(33.33, rel=1e-3)

--- a/tests/unit/reports/test_common.py
+++ b/tests/unit/reports/test_common.py
@@ -154,3 +154,11 @@ def test_summarize_tool_runs_uses_non_overlapping_failure_counts():
     assert summary["safety_blocked"] == 1
     assert summary["successful"] == 1
     assert summary["success_rate"] == pytest.approx(33.33, rel=1e-3)
+
+
+def test_summarize_tool_runs_counts_error_only_failures_in_success_rate():
+    summary = summarize_tool_runs([{"success": False, "error": "boom"}])
+
+    assert summary["failures"] == 1
+    assert summary["successful"] == 0
+    assert summary["success_rate"] == 0.0

--- a/tests/unit/reports/test_common.py
+++ b/tests/unit/reports/test_common.py
@@ -71,7 +71,15 @@ def test_extract_tool_runs_from_unexpected_value():
 def test_extract_tool_runs_from_error_only_entry():
     entry = {"success": False, "error": "phase failed", "exception": "boom"}
     runs, metadata = extract_tool_runs(entry)
-    assert runs == [{"success": False, "error": "phase failed", "exception": "boom", "safety_blocked": False, "safety_sanitized": False}]
+    assert runs == [
+        {
+            "success": False,
+            "error": "phase failed",
+            "exception": "boom",
+            "safety_blocked": False,
+            "safety_sanitized": False,
+        }
+    ]
     assert metadata is entry
 
 

--- a/tests/unit/reports/test_common.py
+++ b/tests/unit/reports/test_common.py
@@ -162,3 +162,10 @@ def test_summarize_tool_runs_counts_error_only_failures_in_success_rate():
     assert summary["failures"] == 1
     assert summary["successful"] == 0
     assert summary["success_rate"] == 0.0
+
+
+def test_summarize_tool_runs_handles_non_dict_safety_blocked_entries():
+    summary = summarize_tool_runs([{"success": True}, "legacy-run"])  # type: ignore[list-item]
+
+    assert summary["safety_blocked"] == 0
+    assert summary["failures"] == 1

--- a/tests/unit/reports/test_formatters.py
+++ b/tests/unit/reports/test_formatters.py
@@ -3,6 +3,7 @@
 Tests for formatters module.
 """
 
+from decimal import Decimal
 import tempfile
 from unittest.mock import MagicMock, patch, mock_open
 
@@ -167,6 +168,26 @@ class TestConsoleFormatter:
 
         table = console_formatter.console.print.call_args[0][0]
         assert table.title == "MCP Resources Fuzzing Summary"
+
+    def test_print_tool_execution_summary_separates_safety_blocked_runs(
+        self, console_formatter
+    ):
+        """Test tool execution summary excludes safety blocks from vulnerabilities."""
+        results = {
+            "safe_tool": [{"success": False, "safety_blocked": True}],
+            "broken_tool": [{"success": False, "error": "boom"}],
+        }
+
+        console_formatter.print_tool_execution_summary(results)
+
+        printed = [
+            str(call.args[0]) for call in console_formatter.console.print.call_args_list
+        ]
+        assert any("Total Safety Blocked: 1" in item for item in printed)
+        assert any("Overall Success Rate: 0.0%" in item for item in printed)
+        assert any("Vulnerabilities Found: 1" in item for item in printed)
+        assert any("broken_tool" in item for item in printed)
+        assert not any("safe_tool: 1/1 failed runs" in item for item in printed)
 
     def test_print_spec_guard_summary_no_checks(self, console_formatter):
         """Test printing spec guard summary without checks."""
@@ -489,6 +510,42 @@ class TestTextFormatter:
             assert "Total Operations Blocked: 5" in content
             assert "Unique Tools Blocked: 3" in content
             assert "Risk Assessment: MEDIUM" in content
+
+        finally:
+            import os
+
+            os.unlink(temp_filename)
+
+    def test_save_text_report_coerces_tool_success_rate_to_float(self, text_formatter):
+        """Test tool success rates render from Decimal-like values."""
+        report_data = {
+            "metadata": {"session_id": "test_session"},
+            "tool_results": {
+                "test_tool": [{"success": True}],
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", delete=False, suffix=".txt"
+        ) as temp_file:
+            temp_filename = temp_file.name
+
+        try:
+            with patch(
+                "mcp_fuzzer.reports.formatters.text_fmt.summarize_tool_runs",
+                return_value={
+                    "total_runs": 1,
+                    "exceptions": 0,
+                    "safety_blocked": 0,
+                    "success_rate": Decimal("100.0"),
+                },
+            ):
+                text_formatter.save_text_report(report_data, temp_filename)
+
+            with open(temp_filename, "r") as f:
+                content = f.read()
+
+            assert "Success Rate: 100.0%" in content
 
         finally:
             import os

--- a/tests/unit/reports/test_output_protocol.py
+++ b/tests/unit/reports/test_output_protocol.py
@@ -19,7 +19,7 @@ from mcp_fuzzer.reports.core.models import (
     RunRecord,
     SummaryStats,
 )
-from mcp_fuzzer.reports.output.protocol import _result_has_failure
+from mcp_fuzzer.reports.formatters.common import result_has_failure
 
 from importlib.metadata import version, PackageNotFoundError
 
@@ -220,14 +220,15 @@ class TestOutputProtocol:
                 {"success": True},
                 {"success": False, "error": "bad"},
                 {"exception": "boom"},
+                {"success": True, "result": {"response": {"error": "nested"}}},
             ]
         }
 
         formatted = self.protocol._format_protocol_results(protocol_results)
         assert len(formatted) == 1
         entry = formatted[0]
-        assert entry["errors"] == 2
-        assert entry["success_rate"] == pytest.approx(33.33, rel=1e-3)
+        assert entry["errors"] == 3
+        assert entry["success_rate"] == pytest.approx(25.0, rel=1e-3)
 
     def test_calculate_error_severity_priorities(self):
         assert self.protocol._calculate_error_severity([]) == "none"
@@ -243,11 +244,12 @@ class TestOutputProtocol:
         assert self.protocol._calculate_error_severity([{}]) == "low"
 
     def test_result_has_failure_detects_flags(self):
-        assert _result_has_failure({"error": "problem"})
-        assert _result_has_failure({"exception": "boom"})
-        assert _result_has_failure({"server_error": "connection failed"})
-        assert _result_has_failure({"success": False})
-        assert not _result_has_failure({"success": True})
+        assert result_has_failure({"error": "problem"})
+        assert result_has_failure({"exception": "boom"})
+        assert result_has_failure({"server_error": "connection failed"})
+        assert result_has_failure({"success": False})
+        assert result_has_failure({"result": {"response": {"error": "nested"}}})
+        assert not result_has_failure({"success": True})
 
     def test_save_output(self):
         """Test saving output to file."""

--- a/tests/unit/reports/test_reporter.py
+++ b/tests/unit/reports/test_reporter.py
@@ -246,6 +246,17 @@ class TestFuzzerReporter:
         # Verify results were stored
         assert "test_tool" in reporter.tool_results
 
+    def test_print_tool_execution_summary(self, reporter):
+        """Test printing tool execution summary."""
+        results = {"test_tool": [{"success": True}, {"exception": "boom"}]}
+
+        reporter.print_tool_execution_summary(results)
+
+        reporter.console_formatter.print_tool_execution_summary.assert_called_once_with(
+            results
+        )
+        assert "test_tool" in reporter.tool_results
+
     def test_print_protocol_summary(self, reporter):
         """Test printing protocol summary."""
         results = {"test_protocol": [{"success": True}, {"error": "test_error"}]}

--- a/tests/unit/reports/test_reporter.py
+++ b/tests/unit/reports/test_reporter.py
@@ -578,3 +578,23 @@ class TestFuzzerReporter:
         reporter.xml_formatter.save_xml_report.assert_called_once()
         reporter.html_formatter.save_html_report.assert_called_once()
         reporter.markdown_formatter.save_markdown_report.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_export_requested_formats_continues_after_failure(
+        self, reporter, tmp_path
+    ):
+        """Test failed exports do not abort later requested formats."""
+        export_targets = {
+            "csv": str(tmp_path / "report.csv"),
+            "xml": str(tmp_path / "report.xml"),
+        }
+        reporter.export_format = AsyncMock(
+            side_effect=[RuntimeError("csv failed"), str(tmp_path / "report.xml")]
+        )
+
+        with patch("mcp_fuzzer.reports.reporter.logging.error") as mock_error:
+            exported = await reporter.export_requested_formats(export_targets)
+
+        assert exported == {"xml": str(tmp_path / "report.xml")}
+        assert reporter.export_format.await_count == 2
+        mock_error.assert_called_once()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Design Changes and Architectural Improvements

This PR introduces a significant **refactoring toward stricter separation of concerns and improved type safety**, moving the codebase from loose, dict-based configurations toward **typed contracts and delegated responsibilities**. The changes follow a clear pattern of extracting business logic from the main client into specialized, purpose-built components.

### Primary Design Changes

1. **Configuration Typing via `TransportBuildRequest`** (Transport Layer)
   - Replaces loose `args` + `client_args` dict pattern with a frozen `@dataclass` that explicitly declares all transport parameters (protocol, endpoint, timeouts, retry settings, auth, safety flag)
   - Moves validation logic from multiple call sites into a single factory function `_build_transport_request()`
   - **Pattern**: Dependency Injection + Data Transfer Object (DTO), improving **Single Responsibility Principle (SRP)**

2. **Reporting Responsibility Delegation** (Main Client → Reporter)
   - Removes direct console printing and standardized report generation from `main.py`
   - Delegates to `FuzzerReporter` via new methods: `print_tool_execution_summary()`, `generate_standardized_report()`, `export_requested_formats()`
   - Consolidates per-format export logic from per-flag checks into a single `_requested_export_targets()` helper that returns a `dict[str, str]` mapping
   - **Pattern**: Facade Pattern + Separation of Concerns, improving **SRP** and cohesion

3. **Protocol Dispatch Refactoring** (Protocol Client)
   - Replaces large inline conditional blocks mapping protocol types to handler methods with a declarative `_PROTOCOL_SPECS` dictionary
   - Each spec entry contains `handler_name`, `method`, and `is_notification` flag, routed through a unified `_send_protocol_action()` dispatcher
   - Removes `ProtocolExecutor` dependency for protocol-type iteration, using instead a module constant `SUPPORTED_PROTOCOL_TYPES`
   - **Pattern**: Strategy Pattern + Configuration as Data, improving **Open/Closed Principle** (OCP) — new protocol types can be added to the spec dict without changing dispatch logic
   - **Change**: `_get_protocol_types()` simplified from async to synchronous, removing hidden error handling

4. **Tool Client Result Standardization** (Tool Client)
   - Extracts `_build_tool_run_result()`, `_execute_tool_call()`, `_call_tool()` helpers to standardize result payloads across safety, timeout, and exception paths
   - Centralizes run metadata (success, safety_blocked, timeout_scope, error type) into consistent dictionary structures
   - Introduces `_run_tool_phase()` to factor phase mutation and processing, reducing duplication between realistic and aggressive phases
   - **Pattern**: Template Method + Helper Extraction, reducing cognitive load and improving **DRY** (Don't Repeat Yourself)

5. **Formatter Utility Extraction** (Reporting)
   - New helpers in `common.py`: `tool_run_has_exception()`, `tool_run_has_failure()`, `summarize_tool_runs()` centralize run aggregation logic
   - Replaces inline computation of success rates and failure counts with a single `summarize_tool_runs()` call returning `{total_runs, exceptions, safety_blocked, failures, success_rate}`
   - **Pattern**: Utility/Helper Function pattern, improving **DRY** and testability

---

## Design Pattern Usage

| Pattern | Location | Purpose |
|---------|----------|---------|
| **Data Transfer Object (DTO)** | `TransportBuildRequest` | Type-safe configuration passing |
| **Facade** | `FuzzerReporter` | Unified reporting interface hiding multiple formatters |
| **Strategy** | `_PROTOCOL_SPECS` dict | Runtime dispatch without conditionals |
| **Template Method** | `_run_tool_phase()` | Reusable phase execution logic |
| **Factory** | `_build_transport_request()`, `build_driver_with_auth()` | Object construction with validation |
| **Protocol/Interface** | `SafetyProvider`, `ReportSaver` in type system | Type-safe abstraction contracts |

---

## SOLID Principles Adherence

### ✅ **Single Responsibility (SRP)** — Improved
- **Before**: `main.py` mixed transport building, reporting, console output, and metadata management
- **After**: Responsibilities distributed: `TransportBuildRequest` for config, `FuzzerReporter` for output, `ToolClient` for execution
- **Before**: `ProtocolClient` contained large handler-dispatch conditionals
- **After**: Dispatch logic moved to declarative `_PROTOCOL_SPECS`, cleanly separated from business logic

### ⚠️ **Open/Closed Principle (OCP)** — Partially Improved
- **Improved**: `_PROTOCOL_SPECS` dictionary makes adding new protocol types closed for modification (edit dict only) ✅
- **Improved**: `_PROTOCOL_SPECS` uses declarative metadata instead of if/elif chains, reducing branching paths
- **Concern**: Error type strings (`"tool_timeout"`, `"safety_blocked"`, `"phase_execution_failed"`, etc.) are still magic strings scattered across code — should be defined as constants/Enum for extensibility

### ⚠️ **Liskov Substitution Principle (LSP)** — Limited Type Safety
- **Improved**: New `Protocol` definitions (`SafetyProvider`, `ReportSaver`) provide structural typing contracts
- **Concern**: Extensive use of `dict[str, Any]` and `Any` type annotations still prevents static type checking from catching incompatibilities at compile time
  - Result payloads built as dict literals without schema validation
  - `extract_tool_runs()` returns untyped tuples; callers must know the structure
  - `_PROTOCOL_SPECS` values are untyped dicts; accessing `spec["handler_name"]` has no type guarantee

### ✅ **Interface Segregation Principle (ISP)** — Good
- `TransportBuildRequest` is lean and focused (10 fields, all relevant to transport building)
- `FuzzerReporter` methods are narrow: `print_tool_execution_summary()`, `export_requested_formats()`, `generate_standardized_report()` each do one thing
- Protocol definitions (`SafetyProvider`, `ProtocolSafetyProvider`) are minimal, specific interfaces

### ⚠️ **Dependency Inversion Principle (DIP)** — Improved but Incomplete
- **Improved**: `build_driver_with_auth()` now accepts `TransportBuildRequest` (concrete contract) instead of loosely typed `args`/`dict`, making dependencies explicit
- **Improved**: Reporter injection into client improves decoupling from console I/O
- **Concern**: `Any` type parameters in `auth_manager`, `safety_system`, and throughout still violate DIP — high-level code depends on low-level implementation details via loose typing

---

## Code and Design Smells Identified

### 🔴 **High Priority**

1. **Magic String Dispatch Without Constants** (Multiple Files)
   - Error types: `"tool_timeout"`, `"safety_blocked"`, `"tool_mutation_failed"`, `"phase_execution_failed"`, `"tool_call_failed"` hardcoded in 17+ locations
   - Impact: Typos not caught at static analysis; inconsistent naming across codebase; difficult refactoring
   - Fix: Define an `Enum` (e.g., `ErrorType.TOOL_TIMEOUT`, `ErrorType.SAFETY_BLOCKED`) or string literals in `constants.py`

2. **Untyped Result Dictionaries** (`dict[str, Any]` Everywhere)
   - Tool run payloads built as `{"success": bool, "error": str, "exception": str, "safety_blocked": bool, ...}` without TypedDict schema
   - `_PROTOCOL_SPECS` values are untyped dicts; accessing `spec["handler_name"]` could fail silently
   - Impact: Runtime errors from missing/misspelled keys; no IDE autocomplete; type checkers cannot validate structure
   - Fix: Create `ToolRunResult` TypedDict with required/optional fields; `ProtocolSpec` TypedDict for spec entries

3. **Inconsistent Result Structure Handling**
   - `extract_tool_runs()` constructs synthetic runs by selectively copying fields (`"args"`, `"label"`, `"error"`, `"exception"`) — logic for what fields to include is implicit
   - `_build_tool_run_result()` conditionally adds `timeout_scope` only if not None, but other fields are always present — inconsistent presence rules
   - Impact: Formatters must understand multiple ways the same result can be structured; fragile code
   - Fix: Standardize result building with explicit defaults; validate all required fields present

4. **Type Annotation Overuse of `Any`**
   - `auth_manager: Any = None` in `TransportBuildRequest`
   - `safety_system: SafetyFilter | Any` in reporter
   - Impact: Defeats purpose of type annotations; cannot detect incompatible usage
   - Fix: Define protocol/interface (e.g., `AuthManager` Protocol) and require conformance

### 🟡 **Medium Priority**

5. **Implicit Knowledge in Helper Functions**
   - `tool_run_has_failure()` classifies failures as: non-dict, safety_blocked, has exception, missing/falsey success, truthy error, or truthy server_error — complex logic without single source of truth for "what is a failure?"
   - Impact: Multiple places could implement this differently; business logic scattered
   - Fix: Centralize failure classification with explicit rules and document contract

6. **Dict Tuple Return Without Named Type**
   - `extract_tool_runs()` returns `tuple[list[dict[str, Any]], dict[str, Any] | None]`; callers unpack as `runs, metadata = extract_tool_runs(...)`
   - Caller must remember: first element is runs, second is metadata; if structure changes, all call sites break
   - Impact: Implicit contracts; refactoring risk
   - Fix: Return a TypedDict like `ExtractedRuns(runs: list[...], metadata: dict | None)`

7. **Protocol Specs Validation Gap**
   - `_PROTOCOL_SPECS` dictionary accessed via `spec["handler_name"]`, `spec["method"]`, `spec["is_notification"]` without validation
   - If a spec entry is missing a key, `KeyError` raised at runtime
   - Impact: No schema validation; missing spec entries silently fail during protocol execution
   - Fix: Define `ProtocolSpec` TypedDict and validate at module load time; use `spec.get(..., default)` or pydantic

8. **Conditional Result Returns Without Enum**
   - `_fuzz_single_tool_with_timeout()` can return different error strings based on error type (timeout vs. general failure)
   - `_execute_tool_call()` similarly returns various error payloads
   - Impact: Error handling in callers must string-match on error type; brittle
   - Fix: Use Enum or tagged unions (e.g., `Union[SuccessResult, TimeoutError, SafetyBlockedError]`)

### 🟢 **Low Priority / Observations**

9. **Removed Error Context** (By Design)
   - `build_driver_with_auth()` now raises `TransportRegistrationError` with context dict instead of calling `sys.exit()`
   - Impact: Callers must handle exception; improves testability and error propagation
   - Status: ✅ Improvement (not a smell)

10. **Simplified `_get_protocol_types()` from Async to Sync**
    - Removes try/except error handling and `ProtocolExecutor` dependency
    - Impact: Simpler code, but guard `await` added in caller even though method is now sync
    - Concern: Minor type safety issue — method is sync but caller still awaits it (though this works in Python)
    - Fix: Remove `await` in callers; make contract explicit as `sync def`

---

## Recommendations for Future Improvements

1. **Define Result Type Hierarchy**
   ```python
   @dataclass(frozen=True)
   class ToolRunResult:
       success: bool
       safety_blocked: bool
       safety_sanitized: bool
       error: ErrorType | None = None
       timeout_scope: TimeoutScope | None = None
       exception: str | None = None
       args: dict[str, Any] | None = None
       result: dict[str, Any] | None = None
   ```

2. **Create Enum for Error and Timeout Types**
   ```python
   class ErrorType(str, Enum):
       SAFETY_BLOCKED = "safety_blocked"
       TOOL_TIMEOUT = "tool_timeout"
       TOOL_MUTATION_FAILED = "tool_mutation_failed"
       # ...
   
   class TimeoutScope(str, Enum):
       CALL = "call"
       SESSION = "session"
   ```

3. **Strongly Type `_PROTOCOL_SPECS`**
   ```python
   @dataclass(frozen=True)
   class ProtocolSpec:
       handler_name: str
       method: str
       is_notification: bool
   
   _PROTOCOL_SPECS: dict[str, ProtocolSpec] = {...}
   ```

4. **Migrate Away from `dict[str, Any]` in Public APIs**
   - Use TypedDict or dataclass for all structured data passed between modules
   - Reserve `dict[str, Any]` for user input or truly dynamic data

5. **Add Schema Validation at Boundaries**
   - Validate `_PROTOCOL_SPECS` entries on module load
   - Use pydantic for config deserialization in `_build_transport_request()`

---

## Summary

This PR **successfully decouples responsibilities** and improves **type contracts** through `TransportBuildRequest` and reporter delegation. The introduction of `_PROTOCOL_SPECS` and helper functions reduces cognitive load. However, **magic strings and untyped dicts undermine these improvements**, preventing static type checking from catching runtime errors. The fixes are straightforward (create Enums and TypedDicts for result structures) and would complete the transition from loosely-typed to strictly-typed architecture.

**Overall Assessment**: 
- **Strengths**: Good separation of concerns, improved factory pattern, cleaner dispatch logic
- **Weaknesses**: Magic strings, overuse of `Any`, implicit result structures
- **SOLID Alignment**: SRP ✅ | OCP ⚠️ (needs constants/Enum) | LSP ⚠️ (needs typed results) | ISP ✅ | DIP ⚠️ (needs typed interfaces)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->