### PR TITLE
Add CLAUDE.md with branch and commit instructions for AI agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# AI Agent Instructions
+
+## Branch Creation
+
+Always create a feature branch before making any code changes:
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b <descriptive-branch-name>
+```
+
+Name the branch after the feature or fix, for example:
+- `oauth-client-credentials-auth`
+- `git-branch-isolation`
+- `fix-batch-auth-bypass`
+
+Never commit directly to `main`.
+
+## Commit Message Style
+
+Follow the project's short imperative style — no trailing period:
+
+```
+Add <feature>
+Fix <bug>
+Refactor <component>
+Update <thing>
+Remove <thing>
+```
+
+Examples from this repo:
+- `Add OAuth client credentials auth`
+- `Add git branch isolation for AI agents`
+- `Fix batch JSON-RPC auth bypass in test server`
+- `Refine reporting boundaries and result contracts`
+
+## Lint and Tests
+
+Run before every commit:
+
+```bash
+tox -e ruff                  # lint
+tox -e tests -- <test paths> # unit tests
+```
+
+## Pull Requests
+
+Open PRs against `main` on `https://github.com/Agent-Hellboy/mcp-server-fuzzer`.

--- a/tests/unit/config/test_discovery_transports.py
+++ b/tests/unit/config/test_discovery_transports.py
@@ -201,6 +201,8 @@ def test_load_custom_transports_logs_with_percent_formatting(monkeypatch):
 
 
 def test_load_custom_transports_invalid_factory_path(monkeypatch):
+    from mcp_fuzzer.config.extensions import transports
+
     dummy_module = SimpleNamespace(DummyTransport=DummyTransport)
 
     def fake_import(name):
@@ -208,14 +210,8 @@ def test_load_custom_transports_invalid_factory_path(monkeypatch):
             return dummy_module
         raise ImportError(name)
 
-    monkeypatch.setattr(
-        "mcp_fuzzer.config.extensions.transports.importlib.import_module",
-        fake_import,
-    )
-    monkeypatch.setattr(
-        "mcp_fuzzer.config.extensions.transports.register_custom_driver",
-        lambda **_kwargs: None,
-    )
+    monkeypatch.setattr(transports.importlib, "import_module", fake_import)
+    monkeypatch.setattr(transports, "register_custom_driver", lambda **_kwargs: None)
 
     config_data = {
         "custom_transports": {
@@ -232,6 +228,8 @@ def test_load_custom_transports_invalid_factory_path(monkeypatch):
 
 
 def test_load_custom_transports_non_callable_factory(monkeypatch):
+    from mcp_fuzzer.config.extensions import transports
+
     dummy_module = SimpleNamespace(DummyTransport=DummyTransport)
     factory_module = SimpleNamespace(not_callable="nope")
 
@@ -242,14 +240,8 @@ def test_load_custom_transports_non_callable_factory(monkeypatch):
             return factory_module
         raise ImportError(name)
 
-    monkeypatch.setattr(
-        "mcp_fuzzer.config.extensions.transports.importlib.import_module",
-        fake_import,
-    )
-    monkeypatch.setattr(
-        "mcp_fuzzer.config.extensions.transports.register_custom_driver",
-        lambda **_kwargs: None,
-    )
+    monkeypatch.setattr(transports.importlib, "import_module", fake_import)
+    monkeypatch.setattr(transports, "register_custom_driver", lambda **_kwargs: None)
 
     config_data = {
         "custom_transports": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR introduces AI agent documentation guidelines and makes a minor README enhancement, alongside a test fixture refactoring. The changes are primarily non-functional additions except for test infrastructure improvements.

## Changes

### 1. CLAUDE.md (New File, 49 lines)
**Purpose**: Documentation for AI agents on development workflows

**Content**:
- Branch naming conventions and creation procedures
- Commit message style guide (imperative, no trailing periods)
- Pre-commit validation checks (linting and testing)
- PR submission guidelines

**Analysis**: This is purely instructional documentation, not a code change. It establishes conventions rather than architectural decisions.

### 2. README.md (1 line added)
Added a PyPI downloads badge to the header section. This is a cosmetic documentation enhancement with no structural impact.

### 3. tests/unit/config/test_discovery_transports.py (8 insertions, 16 deletions)
**Test Fixture Refactoring**:

Changed mocking approach in two test functions:
- `test_load_custom_transports_invalid_factory_path`
- `test_load_custom_transports_non_callable_factory`

**Before**:
```python
monkeypatch.setattr(
    "mcp_fuzzer.config.extensions.transports.importlib.import_module",
    fake_import,
)
```

**After**:
```python
from mcp_fuzzer.config.extensions import transports
monkeypatch.setattr(transports.importlib, "import_module", fake_import)
```

## Design Changes & Patterns Analysis

### Test Design Pattern: Module-Level Mocking
**Pattern Applied**: Moved from **string-based patching** to **direct object reference patching**

**Benefits**:
- **Explicit Dependencies**: The `from mcp_fuzzer.config.extensions import transports` makes the test's dependency on the transports module explicit at the top of the function
- **Refactoring Safety**: Direct references enable IDEs to catch renames during refactoring; string paths may silently fail
- **Readability**: `transports.importlib` is more immediately clear than `"mcp_fuzzer.config.extensions.transports.importlib.import_module"`

**Design Smell Remedied**: The original string-based patching pattern creates **tight coupling through opaque paths** and **implicit dependencies** that are easy to break.

### SOLID Principles Assessment

**Dependency Inversion (DIP)**:
- The refactored tests now explicitly declare what they depend on (importing the `transports` module), making the dependency graph clearer
- Improvement: Reduces accidental brittleness from magic string paths

**Single Responsibility (SRP)**:
- Test functions remain focused: validating error handling for invalid/non-callable factories
- No violations introduced

**Open/Closed Principle (OCP)**:
- String-based mocking created closed behavior where path changes break tests silently
- Direct imports make test maintenance more transparent when modules are reorganized

### Code Smells Addressed
1. **Magic Strings**: Eliminated hardcoded module paths that obscure intent
2. **Brittle Patching**: String-based patches can fail silently if module structure changes
3. **Implicit Dependencies**: Tests now explicitly declare what modules they interact with

### Architectural Observations
- No changes to production code architecture
- Test infrastructure improvement aligns with pytest best practices
- Follows the principle that test code should be as maintainable as production code

<!-- end of auto-generated comment: release notes by coderabbit.ai -->