### PR TITLE
Fix OAuth discovery and registration for restrictive servers

### DIFF
--- a/mcp_fuzzer/auth/discovery.py
+++ b/mcp_fuzzer/auth/discovery.py
@@ -121,15 +121,33 @@ def build_protected_resource_metadata_urls(endpoint_url: str) -> list[str]:
     path = parsed.path or "/"
     normalized_path = path if path.startswith("/") else f"/{path}"
     trimmed_path = normalized_path.strip("/")
+    path_no_trailing = normalized_path.rstrip("/")
 
     candidates = []
     if trimmed_path:
+        # RFC 9728: the well-known segment is inserted *before* the resource
+        # path component.
         candidates.append(
             urlunsplit(
                 (
                     parsed.scheme,
                     parsed.netloc,
                     f"/.well-known/oauth-protected-resource/{trimmed_path}",
+                    "",
+                    "",
+                )
+            )
+        )
+        # Path-suffix form: the well-known segment *appended* after the resource
+        # path. This is what several MCP servers serve (and advertise in the
+        # WWW-Authenticate ``resource_metadata`` URL), and mirrors the path-suffix
+        # variant already produced for authorization-server metadata.
+        candidates.append(
+            urlunsplit(
+                (
+                    parsed.scheme,
+                    parsed.netloc,
+                    f"{path_no_trailing}/.well-known/oauth-protected-resource",
                     "",
                     "",
                 )

--- a/mcp_fuzzer/auth/oauth/flow.py
+++ b/mcp_fuzzer/auth/oauth/flow.py
@@ -242,14 +242,34 @@ class MCPAuthorizationFlow:
         # 3. Dynamic Client Registration -- register the *actual* redirect URI
         #    so it matches the authorization request (exact-match validation).
         if as_metadata.registration_endpoint:
-            registration = register_dynamic_client(
-                as_metadata.registration_endpoint,
-                redirect_uris=[redirect_uri] if redirect_uri else [],
-                client_name=self.config.client_name,
-                scope=self._resolve_scope(),
-                http=self._http,
-                timeout=self.config.timeout,
-            )
+            reg_kwargs: dict[str, Any] = {
+                "redirect_uris": [redirect_uri] if redirect_uri else [],
+                "client_name": self.config.client_name,
+                "http": self._http,
+                "timeout": self.config.timeout,
+            }
+            scope = self._resolve_scope()
+            try:
+                registration = register_dynamic_client(
+                    as_metadata.registration_endpoint, scope=scope, **reg_kwargs
+                )
+            except AuthProviderError:
+                # ``scope`` is optional in RFC 7591 and is still requested in the
+                # authorization request, so it is not required at registration
+                # time. Some authorization servers (e.g. locked-down Keycloak
+                # realms whose "Allowed Client Scopes" policy rejects anonymous
+                # registration that names scopes) only accept a scope-less
+                # registration -- retry once without it before giving up.
+                if not scope:
+                    raise
+                logger.info(
+                    "Dynamic client registration with scope=%r was rejected; "
+                    "retrying without the optional scope parameter",
+                    scope,
+                )
+                registration = register_dynamic_client(
+                    as_metadata.registration_endpoint, scope=None, **reg_kwargs
+                )
             return registration["client_id"], registration.get("client_secret")
         raise AuthProviderError(
             "No client credentials available: provide a client_id, a Client ID "

--- a/tests/unit/auth/test_discovery.py
+++ b/tests/unit/auth/test_discovery.py
@@ -49,6 +49,7 @@ def test_build_protected_resource_metadata_urls_prefers_endpoint_path():
 
     assert urls == [
         "https://mcp.example.com/.well-known/oauth-protected-resource/public/mcp",
+        "https://mcp.example.com/public/mcp/.well-known/oauth-protected-resource",
         "https://mcp.example.com/.well-known/oauth-protected-resource",
     ]
 

--- a/tests/unit/auth/test_oauth.py
+++ b/tests/unit/auth/test_oauth.py
@@ -222,6 +222,53 @@ def test_register_dynamic_client_error():
             )
 
 
+def test_resolve_client_retries_registration_without_scope():
+    """A registration rejected for naming scopes is retried without scope."""
+    from mcp_fuzzer.auth.oauth import AuthorizationServerMetadata
+
+    attempts: list[bool] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+
+        body = json.loads(request.content.decode())
+        has_scope = "scope" in body
+        attempts.append(has_scope)
+        if has_scope:
+            # Locked-down realm: rejects anonymous registration naming scopes.
+            return httpx.Response(403, text="insufficient_scope")
+        return httpx.Response(201, json={"client_id": "dyn-noscope"})
+
+    as_metadata = AuthorizationServerMetadata(
+        issuer="https://auth.example.com",
+        authorization_endpoint="https://auth.example.com/authorize",
+        token_endpoint="https://auth.example.com/token",
+        registration_endpoint="https://auth.example.com/register",
+        code_challenge_methods_supported=["S256"],
+        scopes_supported=[],
+        grant_types_supported=[],
+        token_endpoint_auth_methods_supported=[],
+        client_id_metadata_document_supported=False,
+        metadata_url="https://auth.example.com/.well-known/oauth-authorization-server",
+        raw={},
+    )
+
+    with _mock_client(handler) as http:
+        flow = MCPAuthorizationFlow(
+            "https://mcp.example.com/mcp",
+            OAuthClientConfig(scope="openid profile email"),
+            http=http,
+        )
+        client_id, client_secret = flow._resolve_client(
+            as_metadata, redirect_uri="http://127.0.0.1:5000/callback"
+        )
+
+    assert client_id == "dyn-noscope"
+    assert client_secret is None
+    # First attempt carried the scope (rejected), second omitted it (accepted).
+    assert attempts == [True, False]
+
+
 def test_exchange_code_includes_pkce_and_resource():
     captured = {}
 

--- a/tests/unit/transport/test_stream_http_driver.py
+++ b/tests/unit/transport/test_stream_http_driver.py
@@ -1006,6 +1006,7 @@ async def test_probe_auth_discovery_falls_back_to_well_known(monkeypatch):
 
     assert result["protected_resource_metadata_urls"] == [
         "https://redirected.example.com/.well-known/oauth-protected-resource/alt/mcp",
+        "https://redirected.example.com/alt/mcp/.well-known/oauth-protected-resource",
         "https://redirected.example.com/.well-known/oauth-protected-resource",
     ]
     assert result["required_scopes"] == []


### PR DESCRIPTION
## What

Fixes two gaps in the `--oauth` (MCP 2025-11-25 spec-driven) authorization flow that surfaced while fuzzing a real Keycloak-protected MCP server.

1. **Protected Resource Metadata discovery** now also tries the path-suffix form `…/<path>/.well-known/oauth-protected-resource`, in addition to the RFC 9728 path-aware and root forms. Several MCP servers serve metadata there (and advertise it in the `WWW-Authenticate: resource_metadata` URL). Mirrors the path-suffix variant already produced for authorization-server metadata. Without it, discovery 404s and the flow aborts before authentication.
2. **Dynamic Client Registration** retries once without the optional RFC 7591 `scope` if a scoped registration is rejected (e.g. Keycloak's "Allowed Client Scopes" policy returns `403 insufficient_scope` for anonymous registration that names scopes). The scope is still requested in the authorization request, so nothing is lost.

## Why

After these fixes, a no-credentials run (`--oauth --oauth-open-browser`) discovers metadata, dynamically registers a public PKCE client, completes the browser login, caches the token, and fuzzes authenticated tools — verified end-to-end against a live Keycloak-protected server.

## Testing
- `tox -e ruff` clean on changed files
- `tox -e tests -- tests/unit/auth/ tests/unit/transport/test_stream_http_driver.py` → 212 passed
- Added scope-fallback registration test; updated discovery URL-list expectations
- Manually verified the full flow end-to-end against a live Keycloak-protected MCP server

## Related
Docs for the `--oauth` flow are in #170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)