### PR TITLE
Document --oauth spec-driven authentication flow

### DIFF
--- a/docs/development/reference.md
+++ b/docs/development/reference.md
@@ -44,8 +44,9 @@ mcp-fuzzer [OPTIONS] --mode {tools|protocol|resources|prompts|all} --protocol {h
 | `--transport-retry-backoff` | Float | 2.0 | Backoff multiplier for transport retry delay |
 | `--transport-retry-max-delay` | Float | 5.0 | Maximum delay between retries (seconds) |
 | `--transport-retry-jitter` | Float | 0.1 | Jitter factor for retry delay |
-| `--auth-config` | Path | - | Path to authentication configuration file |
-| `--auth-env` | Flag | False | Use authentication from environment variables |
+
+> Authentication flags (`--auth-config`, `--auth-env`, `--oauth*`) are listed
+> under [Authentication Options](#authentication-options).
 
 Notes:
 
@@ -100,6 +101,31 @@ Notes:
 |--------|------|---------|-------------|
 | `--no-network` | Flag | False | Disallow network to non-local hosts |
 | `--allow-host` | String | - | Permit additional hostnames when `--no-network` is set (repeatable) |
+
+### Authentication Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--auth-config` | Path | - | Path to a JSON authentication configuration file (static providers + tool mapping) |
+| `--auth-env` | Flag | False | Load authentication from environment variables (`MCP_API_KEY`, `MCP_USERNAME`/`MCP_PASSWORD`, `MCP_OAUTH_*`, …) |
+| `--oauth` | Flag | False | Run the MCP OAuth 2.1 authorization flow (RFC 9728/8414 discovery → client → grant) to obtain a bearer token. Requires `--endpoint` |
+| `--oauth-grant` | Choice | authorization_code | Grant to use: `authorization_code` (PKCE, browser, user-delegated) or `client_credentials` (machine-to-machine) |
+| `--oauth-client-id` | String | - | Pre-registered client id (skips dynamic registration). Falls back to `MCP_OAUTH_CLIENT_ID` |
+| `--oauth-client-secret` | String | - | Client secret for a confidential client. Falls back to `MCP_OAUTH_CLIENT_SECRET` |
+| `--oauth-scope` | String | - | OAuth scope(s) to request (space-separated). Falls back to `MCP_OAUTH_SCOPE` |
+| `--oauth-client-id-metadata-url` | String | - | HTTPS URL of a Client ID Metadata Document to use as the `client_id` |
+| `--oauth-open-browser` | Flag | False | Auto-open the browser for the authorization-code flow (off by default; the URL is printed instead) |
+| `--oauth-no-token-cache` | Flag | False | Disable the on-disk token cache (`~/.cache/mcp-fuzzer/oauth/`); re-authorize every run |
+
+Notes:
+
+- Auth source priority: `--oauth` → `--auth-config` → YAML `auth` section →
+  `--auth-env` → auto-detected env vars → none.
+- With `--oauth`, if no client id is supplied the fuzzer attempts Dynamic Client
+  Registration (RFC 7591) against the discovered authorization server, registering
+  a public PKCE-only client with the exact loopback redirect URI.
+- See [Authentication](../getting-started/getting-started.md#authentication) for
+  worked examples.
 
 ### Reporting Options
 

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -287,6 +287,90 @@ export MCP_PASSWORD="password"
 mcp-fuzzer --mode tools --protocol http --auth-env --endpoint http://localhost:8000
 ```
 
+### MCP OAuth 2.1 Authorization (`--oauth`)
+
+The methods above attach a **static** credential you already hold (an API key, a
+bearer token, or a client id/secret for a known token endpoint). When the MCP
+server is an OAuth 2.1 *protected resource* — it answers an unauthenticated
+request with `401` and a `WWW-Authenticate: Bearer resource_metadata="..."`
+header — the fuzzer can acquire a token for you with the `--oauth` flag. No
+hand-built `auth_config.json` is needed.
+
+`--oauth` runs the full MCP authorization flow (per the MCP 2025-11-25 spec):
+
+1. **Discover** the Protected Resource Metadata (RFC 9728) and the Authorization
+   Server Metadata (RFC 8414) starting from the endpoint's `.well-known`
+   documents / `WWW-Authenticate` challenge.
+2. **Obtain a client** — use a pre-registered `--oauth-client-id`, a Client ID
+   Metadata Document URL, or fall back to Dynamic Client Registration (RFC 7591)
+   if the server's authorization server supports it.
+3. **Run the grant** — `authorization_code` with PKCE (browser, user-delegated)
+   or `client_credentials` (machine-to-machine).
+4. **Attach** the resulting bearer token to every fuzzing request and refresh it
+   transparently when it expires.
+
+The acquired token is cached on disk (under `~/.cache/mcp-fuzzer/oauth/`, or
+`$XDG_CACHE_HOME/mcp-fuzzer/oauth/`) so the browser step happens at most once;
+subsequent runs reuse or silently refresh it. Use `--oauth-no-token-cache` to
+disable this.
+
+#### Authorization code + PKCE (browser-based, default)
+
+Use this for user-delegated access. The fuzzer starts a one-shot
+`http://127.0.0.1:<port>/callback` loopback server, prints (or opens) the
+authorization URL, and waits for the redirect after you log in.
+
+```bash
+mcp-fuzzer --mode tools --protocol streamablehttp \
+  --endpoint https://your-server.example.com/mcp \
+  --oauth --oauth-open-browser --runs 5
+```
+
+If the authorization server supports anonymous Dynamic Client Registration, the
+command above needs nothing else — the fuzzer registers a public, PKCE-only
+client on the fly with the exact loopback redirect URI. To reuse a
+pre-registered client instead, pass `--oauth-client-id` (and
+`--oauth-client-secret` for a confidential client). When using a pre-registered
+client, its allowed redirect URIs must permit the loopback callback (e.g. a
+`http://127.0.0.1/*` pattern), since the port is chosen at runtime.
+
+Omit `--oauth-open-browser` for unattended runs: the URL is printed to the log
+instead of hijacking a browser.
+
+#### Client credentials (machine-to-machine, non-interactive)
+
+Use this for a confidential service client with no user in the loop:
+
+```bash
+mcp-fuzzer --mode tools --protocol streamablehttp \
+  --endpoint https://your-server.example.com/mcp \
+  --oauth --oauth-grant client_credentials \
+  --oauth-client-id my-service --oauth-client-secret "$CLIENT_SECRET" \
+  --oauth-scope "openid profile email"
+```
+
+To keep the secret off the command line, set `MCP_OAUTH_CLIENT_ID`,
+`MCP_OAUTH_CLIENT_SECRET`, and `MCP_OAUTH_SCOPE` in the environment; CLI flags
+take precedence over these when both are present.
+
+#### Example: a Keycloak-protected server
+
+A server that returns
+`WWW-Authenticate: Bearer resource_metadata="https://host/mcp/.well-known/oauth-protected-resource"`
+pointing at a Keycloak realm works out of the box. If the realm allows anonymous
+client registration and advertises PKCE `S256`, this is the entire command:
+
+```bash
+mcp-fuzzer --mode tools --protocol streamablehttp \
+  --endpoint https://host/mcp --oauth --oauth-open-browser --runs 5
+```
+
+Log in as a realm test user when the browser opens; the fuzzer captures the
+redirect, exchanges the code, and fuzzes the authenticated tools.
+
+> See the [CLI Reference](../development/reference.md#authentication-options) for
+> the full list of `--oauth*` flags.
+
 ## Safety System
 
 ### Basic Safety Features


### PR DESCRIPTION
## What

Documents the `--oauth` (MCP 2025-11-25 spec-driven) authorization flow, which previously was only discoverable by reading the source.

- New **"MCP OAuth 2.1 Authorization (`--oauth`)"** section in Getting Started: the discovery → client → grant flow, both `authorization_code`+PKCE and `client_credentials` grants, the on-disk token cache, env-var fallback for secrets, and a worked Keycloak example.
- New **Authentication Options** table in the CLI Reference covering all `--oauth*` flags plus `--auth-config`/`--auth-env`, the auth-source priority order, and the DCR fallback behavior.

## Why

The Authentication docs only covered static credentials (api_key / basic / oauth token / oauth_client_credentials via auth-config or env vars). Fuzzing an OAuth-protected server meant reverse-engineering the flow from the code. This closes that gap.

## Notes

Docs only — no code changes. The discovery/registration fixes that make `--oauth` work against restrictive (e.g. Keycloak) servers are in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)