### PR TITLE
Fix CLI exit code when fail-if-no-tools blocks run

### DIFF
--- a/mcp_fuzzer/cli/entrypoint.py
+++ b/mcp_fuzzer/cli/entrypoint.py
@@ -18,6 +18,7 @@ from .validators import ValidationManager
 from ..logging import setup_logging
 from .parser import parse_arguments
 from .startup_info import print_startup_info
+from .exit_codes import INTERRUPTED
 
 
 def _print_mcp_error(error: MCPError) -> None:
@@ -78,7 +79,7 @@ def run_cli() -> None:
     except KeyboardInterrupt:
         console = Console()
         console.print("\n[yellow]Fuzzing interrupted by user[/yellow]")
-        sys.exit(0)
+        sys.exit(INTERRUPTED)
     except MCPError as err:
         _print_mcp_error(err)
         sys.exit(1)

--- a/mcp_fuzzer/cli/entrypoint.py
+++ b/mcp_fuzzer/cli/entrypoint.py
@@ -72,6 +72,7 @@ def run_cli() -> None:
             args,
             lambda: run_fuzz_app(session_settings),
             argv,
+            safety=safety,
         )
         sys.exit(exit_code)
     except KeyboardInterrupt:

--- a/mcp_fuzzer/cli/entrypoint.py
+++ b/mcp_fuzzer/cli/entrypoint.py
@@ -68,11 +68,12 @@ def run_cli() -> None:
 
         argv = prepare_inner_argv(args)
 
-        run_with_retry_on_interrupt(
+        exit_code = run_with_retry_on_interrupt(
             args,
             lambda: run_fuzz_app(session_settings),
             argv,
         )
+        sys.exit(exit_code)
     except KeyboardInterrupt:
         console = Console()
         console.print("\n[yellow]Fuzzing interrupted by user[/yellow]")

--- a/mcp_fuzzer/cli/exit_codes.py
+++ b/mcp_fuzzer/cli/exit_codes.py
@@ -1,0 +1,22 @@
+"""Process exit codes for the CLI fuzzer."""
+
+from __future__ import annotations
+
+SUCCESS = 0
+"""Normal completion."""
+
+GENERAL_ERROR = 1
+"""Validation, bootstrap, or execution failure."""
+
+NO_TOOLS_AVAILABLE = 2
+"""No tools discovered and ``--fail-if-no-tools`` is set."""
+
+INTERRUPTED = 130
+"""Run stopped by user interrupt (SIGINT / Ctrl+C)."""
+
+__all__ = [
+    "GENERAL_ERROR",
+    "INTERRUPTED",
+    "NO_TOOLS_AVAILABLE",
+    "SUCCESS",
+]

--- a/mcp_fuzzer/cli/post_run.py
+++ b/mcp_fuzzer/cli/post_run.py
@@ -13,6 +13,7 @@ from ..reports.formatters.plain_summary import write_stdout_summary
 from ..reports.run_summary import build_run_summary, write_run_summary
 from ..reports.report_presenter import FuzzReportPresenter
 from .session_settings import SessionSettings
+from .exit_codes import NO_TOOLS_AVAILABLE, SUCCESS
 
 
 def _requested_export_targets(config: dict[str, Any]) -> dict[str, str]:
@@ -146,9 +147,9 @@ class PostRunPresenter:
                 "--fail-if-no-tools%s",
                 f" ({detail})" if detail else "",
             )
-            return 2
+            return NO_TOOLS_AVAILABLE
 
-        return 0
+        return SUCCESS
 
 
 __all__ = ["PostRunPresenter"]

--- a/mcp_fuzzer/cli/runtime/async_runner.py
+++ b/mcp_fuzzer/cli/runtime/async_runner.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import signal
 import sys
@@ -13,15 +14,23 @@ from typing import Any, Awaitable, Callable, TypeVar
 from rich.console import Console
 
 from ...client.safety import SafetyController
+from ..exit_codes import INTERRUPTED, SUCCESS
 
 _T = TypeVar("_T")
+logger = logging.getLogger(__name__)
 
 
 def _coerce_exit_code(result: object | None) -> int:
     """Normalize coroutine return values into a process exit code."""
     if isinstance(result, int):
         return result
-    return 0
+    if result is not None:
+        logger.warning(
+            "Expected coroutine to return int exit code, got %r; using %s",
+            result,
+            SUCCESS,
+        )
+    return SUCCESS
 
 
 class AsyncRunner:
@@ -40,7 +49,7 @@ class AsyncRunner:
     ) -> int:
         """Main execution method that orchestrates the entire async runtime."""
         self._setup_environment(argv)
-        exit_code = 0
+        exit_code = SUCCESS
 
         try:
             if self._is_pytest_environment():
@@ -57,6 +66,7 @@ class AsyncRunner:
                 )
             except asyncio.CancelledError:
                 self._handle_cancellation()
+                exit_code = INTERRUPTED
             finally:
                 self._cleanup_pending_tasks()
 
@@ -180,14 +190,18 @@ class AsyncRunner:
         if self.loop:
             self.loop.close()
         sys.argv = self.old_argv
-        if self.should_exit:
-            raise SystemExit(130)
 
 
-def execute_inner_client(args: Any, unified_client_main, argv: list[str]) -> int:
-    """Simple wrapper that creates a runner and executes."""
-    safety = SafetyController()
-    runner = AsyncRunner(args, safety)
+def execute_inner_client(
+    args: Any,
+    unified_client_main,
+    argv: list[str],
+    *,
+    safety: SafetyController | None = None,
+) -> int:
+    """Run the inner client coroutine and return its process exit code."""
+    controller = safety if safety is not None else SafetyController()
+    runner = AsyncRunner(args, controller)
     return runner.run(unified_client_main, argv)
 
 

--- a/mcp_fuzzer/cli/runtime/async_runner.py
+++ b/mcp_fuzzer/cli/runtime/async_runner.py
@@ -14,7 +14,7 @@ from typing import Any, Awaitable, Callable, TypeVar
 from rich.console import Console
 
 from ...client.safety import SafetyController
-from ..exit_codes import INTERRUPTED, SUCCESS
+from ..exit_codes import GENERAL_ERROR, INTERRUPTED, SUCCESS
 
 _T = TypeVar("_T")
 logger = logging.getLogger(__name__)
@@ -28,8 +28,9 @@ def _coerce_exit_code(result: object | None) -> int:
         logger.warning(
             "Expected coroutine to return int exit code, got %r; using %s",
             result,
-            SUCCESS,
+            GENERAL_ERROR,
         )
+        return GENERAL_ERROR
     return SUCCESS
 
 

--- a/mcp_fuzzer/cli/runtime/async_runner.py
+++ b/mcp_fuzzer/cli/runtime/async_runner.py
@@ -7,13 +7,21 @@ import asyncio
 import os
 import signal
 import sys
-from typing import Any, Awaitable, Callable
-
 import importlib.util
+from typing import Any, Awaitable, Callable, TypeVar
 
 from rich.console import Console
 
 from ...client.safety import SafetyController
+
+_T = TypeVar("_T")
+
+
+def _coerce_exit_code(result: object | None) -> int:
+    """Normalize coroutine return values into a process exit code."""
+    if isinstance(result, int):
+        return result
+    return 0
 
 
 class AsyncRunner:
@@ -27,14 +35,16 @@ class AsyncRunner:
         self._signal_notice_printed = False
         self.safety = safety
 
-    def run(self, main_coro: Callable[[], Awaitable[object]], argv: list[str]) -> None:
+    def run(
+        self, main_coro: Callable[[], Awaitable[_T]], argv: list[str]
+    ) -> int:
         """Main execution method that orchestrates the entire async runtime."""
         self._setup_environment(argv)
+        exit_code = 0
 
         try:
             if self._is_pytest_environment():
-                asyncio.run(main_coro())
-                return
+                return _coerce_exit_code(asyncio.run(main_coro()))
 
             self._setup_event_loop()
             self._setup_aiomonitor()
@@ -42,7 +52,9 @@ class AsyncRunner:
 
             try:
                 self._configure_network_policy()
-                self._execute_main_coroutine(main_coro)
+                exit_code = _coerce_exit_code(
+                    self._execute_main_coroutine(main_coro)
+                )
             except asyncio.CancelledError:
                 self._handle_cancellation()
             finally:
@@ -50,6 +62,8 @@ class AsyncRunner:
 
         finally:
             self._final_cleanup()
+
+        return exit_code
 
     def _setup_environment(self, argv: list[str]) -> None:
         """Setup environment variables and argv."""
@@ -121,8 +135,8 @@ class AsyncRunner:
         )
 
     def _execute_main_coroutine(
-        self, main_coro: Callable[[], Awaitable[object]]
-    ) -> None:
+        self, main_coro: Callable[[], Awaitable[_T]]
+    ) -> _T | None:
         """Execute the main coroutine with optional monitoring."""
         enable_aiomonitor = getattr(self.args, "enable_aiomonitor", False)
 
@@ -134,9 +148,8 @@ class AsyncRunner:
                 console_enabled=True,
                 locals=True,
             ):
-                self.loop.run_until_complete(main_coro())
-        else:
-            self.loop.run_until_complete(main_coro())
+                return self.loop.run_until_complete(main_coro())
+        return self.loop.run_until_complete(main_coro())
 
     def _handle_cancellation(self) -> None:
         """Handle cancellation from signal interruption."""
@@ -171,11 +184,11 @@ class AsyncRunner:
             raise SystemExit(130)
 
 
-def execute_inner_client(args: Any, unified_client_main, argv: list[str]) -> None:
+def execute_inner_client(args: Any, unified_client_main, argv: list[str]) -> int:
     """Simple wrapper that creates a runner and executes."""
     safety = SafetyController()
     runner = AsyncRunner(args, safety)
-    runner.run(unified_client_main, argv)
+    return runner.run(unified_client_main, argv)
 
 
 __all__ = ["AsyncRunner", "execute_inner_client"]

--- a/mcp_fuzzer/cli/runtime/retry.py
+++ b/mcp_fuzzer/cli/runtime/retry.py
@@ -7,15 +7,24 @@ from typing import Any, Callable
 
 from rich.console import Console
 
+from ...client.safety import SafetyController
 from ...safety_system import start_system_blocking, stop_system_blocking
+from ..exit_codes import INTERRUPTED
 from .async_runner import execute_inner_client
 
 
 def run_with_retry_on_interrupt(
-    args: Any, unified_client_main: Callable, argv: list[str]
+    args: Any,
+    unified_client_main: Callable,
+    argv: list[str],
+    *,
+    safety: SafetyController | None = None,
 ) -> int:
+    """Execute the client, retrying once with safety after interrupt when configured."""
     try:
-        return execute_inner_client(args, unified_client_main, argv)
+        return execute_inner_client(
+            args, unified_client_main, argv, safety=safety
+        )
     except KeyboardInterrupt:
         console = Console()
         if (not getattr(args, "enable_safety_system", False)) and getattr(
@@ -32,13 +41,15 @@ def run_with_retry_on_interrupt(
             except Exception:  # pragma: no cover
                 pass
             try:
-                return execute_inner_client(args, unified_client_main, argv)
+                return execute_inner_client(
+                    args, unified_client_main, argv, safety=safety
+                )
             finally:
                 if started:
                     stop_system_blocking()
         else:
             console.print("\n[yellow]Fuzzing interrupted by user[/yellow]")
-            raise SystemExit(130)
+            return INTERRUPTED
 
 
 __all__ = ["run_with_retry_on_interrupt"]

--- a/mcp_fuzzer/cli/runtime/retry.py
+++ b/mcp_fuzzer/cli/runtime/retry.py
@@ -13,9 +13,9 @@ from .async_runner import execute_inner_client
 
 def run_with_retry_on_interrupt(
     args: Any, unified_client_main: Callable, argv: list[str]
-) -> None:
+) -> int:
     try:
-        execute_inner_client(args, unified_client_main, argv)
+        return execute_inner_client(args, unified_client_main, argv)
     except KeyboardInterrupt:
         console = Console()
         if (not getattr(args, "enable_safety_system", False)) and getattr(
@@ -32,7 +32,7 @@ def run_with_retry_on_interrupt(
             except Exception:  # pragma: no cover
                 pass
             try:
-                execute_inner_client(args, unified_client_main, argv)
+                return execute_inner_client(args, unified_client_main, argv)
             finally:
                 if started:
                     stop_system_blocking()

--- a/mcp_fuzzer/cli/runtime/retry.py
+++ b/mcp_fuzzer/cli/runtime/retry.py
@@ -41,9 +41,15 @@ def run_with_retry_on_interrupt(
             except Exception:  # pragma: no cover
                 pass
             try:
-                return execute_inner_client(
-                    args, unified_client_main, argv, safety=safety
-                )
+                try:
+                    return execute_inner_client(
+                        args, unified_client_main, argv, safety=safety
+                    )
+                except KeyboardInterrupt:
+                    console.print(
+                        "\n[yellow]Fuzzing interrupted by user[/yellow]"
+                    )
+                    return INTERRUPTED
             finally:
                 if started:
                     stop_system_blocking()

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -438,7 +438,7 @@ def test_run_with_retry_on_interrupt_retry_path():
     args = MagicMock(enable_safety_system=False, retry_with_safety_on_interrupt=True)
     calls = {"n": 0}
 
-    def fake_execute(_args, _main, _argv):
+    def fake_execute(_args, _main, _argv, **kwargs):
         calls["n"] += 1
         if calls["n"] == 1:
             raise KeyboardInterrupt()
@@ -452,7 +452,8 @@ def test_run_with_retry_on_interrupt_retry_path():
         patch("mcp_fuzzer.cli.runtime.retry.start_system_blocking") as mock_start,
         patch("mcp_fuzzer.cli.runtime.retry.stop_system_blocking") as mock_stop,
     ):
-        run_with_retry_on_interrupt(args, lambda: None, ["prog"])
+        exit_code = run_with_retry_on_interrupt(args, lambda: None, ["prog"])
+        assert exit_code == 0
         assert calls["n"] == 2
         mock_start.assert_called_once()
         mock_stop.assert_called_once()
@@ -728,6 +729,7 @@ def test_cli_fail_if_no_tools_blocked_exits_two(tmp_path):
         env={**os.environ, "PYTHONPATH": str(root)},
         capture_output=True,
         text=True,
+        timeout=60,
     )
     assert proc.returncode == 2
     assert (out / "run_summary.json").exists()

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -459,6 +459,26 @@ def test_run_with_retry_on_interrupt_retry_path():
         mock_stop.assert_called_once()
 
 
+def test_run_with_retry_on_interrupt_second_interrupt_returns_130():
+    args = MagicMock(enable_safety_system=False, retry_with_safety_on_interrupt=True)
+    calls = {"n": 0}
+
+    def fake_execute(_args, _main, _argv, **kwargs):
+        calls["n"] += 1
+        raise KeyboardInterrupt()
+
+    with (
+        patch(
+            "mcp_fuzzer.cli.runtime.retry.execute_inner_client",
+            side_effect=fake_execute,
+        ),
+        patch("mcp_fuzzer.cli.runtime.retry.start_system_blocking"),
+        patch("mcp_fuzzer.cli.runtime.retry.stop_system_blocking"),
+    ):
+        assert run_with_retry_on_interrupt(args, lambda: None, ["prog"]) == 130
+        assert calls["n"] == 2
+
+
 def test_validate_transport_errors():
     validator = ValidationManager()
     args = argparse.Namespace(protocol="http", endpoint="http://x", timeout=1)
@@ -617,10 +637,7 @@ def test_run_cli_keyboard_interrupt(monkeypatch):
     ):
         with pytest.raises(SystemExit) as exc:
             run_cli()
-        assert exc.value.code == 0
-
-
-def test_run_cli_validate_config_exits(monkeypatch):
+        assert exc.value.code == 130
     args = _base_args(validate_config="file.yml")
     with (
         patch("mcp_fuzzer.cli.entrypoint.parse_arguments", return_value=args),

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -401,11 +401,10 @@ def test_execute_inner_client_pytest_branch(monkeypatch):
     monkeypatch.setenv("PYTEST_CURRENT_TEST", "1")
 
     async def dummy_main():
-        return None
+        return 2
 
-    with patch("mcp_fuzzer.cli.runtime.async_runner.asyncio.run") as mock_run:
-        execute_inner_client(argparse.Namespace(), dummy_main, ["prog"])
-        mock_run.assert_called_once()
+    with patch("mcp_fuzzer.cli.runtime.async_runner.asyncio.run", return_value=2):
+        assert execute_inner_client(argparse.Namespace(), dummy_main, ["prog"]) == 2
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
 
 
@@ -443,6 +442,7 @@ def test_run_with_retry_on_interrupt_retry_path():
         calls["n"] += 1
         if calls["n"] == 1:
             raise KeyboardInterrupt()
+        return 0
 
     with (
         patch(
@@ -499,13 +499,33 @@ def test_run_cli_happy_path():
         patch("mcp_fuzzer.cli.entrypoint.setup_logging"),
         patch("mcp_fuzzer.cli.entrypoint.print_startup_info"),
         patch("mcp_fuzzer.cli.entrypoint.ValidationManager") as mock_vm_cls,
-        patch("mcp_fuzzer.cli.entrypoint.run_with_retry_on_interrupt"),
+        patch("mcp_fuzzer.cli.entrypoint.run_with_retry_on_interrupt", return_value=0),
         patch("mcp_fuzzer.cli.entrypoint.SessionSettings"),
     ):
         mock_validator = mock_vm_cls.return_value
         mock_validator.validate_arguments.return_value = None
         mock_validator.validate_transport.return_value = None
-        run_cli()
+        with pytest.raises(SystemExit) as exc:
+            run_cli()
+        assert exc.value.code == 0
+
+
+def test_run_cli_propagates_fuzz_exit_code():
+    args = _base_args()
+    with (
+        patch("mcp_fuzzer.cli.entrypoint.parse_arguments", return_value=args),
+        patch("mcp_fuzzer.cli.entrypoint.setup_logging"),
+        patch("mcp_fuzzer.cli.entrypoint.print_startup_info"),
+        patch("mcp_fuzzer.cli.entrypoint.ValidationManager") as mock_vm_cls,
+        patch("mcp_fuzzer.cli.entrypoint.run_with_retry_on_interrupt", return_value=2),
+        patch("mcp_fuzzer.cli.entrypoint.SessionSettings"),
+    ):
+        mock_validator = mock_vm_cls.return_value
+        mock_validator.validate_arguments.return_value = None
+        mock_validator.validate_transport.return_value = None
+        with pytest.raises(SystemExit) as exc:
+            run_cli()
+        assert exc.value.code == 2
 
 
 def test_run_cli_orchestration_invokes_runner():
@@ -521,13 +541,18 @@ def test_run_cli_orchestration_invokes_runner():
         patch("mcp_fuzzer.cli.entrypoint.prepare_inner_argv", return_value=["prog"]),
         patch("mcp_fuzzer.cli.entrypoint.SessionSettings") as mock_settings_cls,
         patch("mcp_fuzzer.cli.entrypoint.SafetyController") as mock_safety_cls,
-        patch("mcp_fuzzer.cli.entrypoint.run_with_retry_on_interrupt") as mock_runner,
+        patch(
+            "mcp_fuzzer.cli.entrypoint.run_with_retry_on_interrupt",
+            return_value=0,
+        ) as mock_runner,
     ):
         mock_validator = mock_vm_cls.return_value
         mock_validator.validate_arguments.return_value = None
         mock_validator.validate_transport.return_value = None
         mock_safety = mock_safety_cls.return_value
-        run_cli()
+        with pytest.raises(SystemExit) as exc:
+            run_cli()
+        assert exc.value.code == 0
         mock_settings_cls.assert_called_once_with(merged)
         mock_safety.start_if_enabled.assert_called_once_with(True)
         mock_runner.assert_called_once()
@@ -555,7 +580,7 @@ def test_run_cli_uses_endpoint_loaded_from_config():
         patch("mcp_fuzzer.cli.entrypoint.prepare_inner_argv", return_value=["prog"]),
         patch("mcp_fuzzer.cli.entrypoint.SessionSettings"),
         patch("mcp_fuzzer.cli.entrypoint.SafetyController"),
-        patch("mcp_fuzzer.cli.entrypoint.run_with_retry_on_interrupt"),
+        patch("mcp_fuzzer.cli.entrypoint.run_with_retry_on_interrupt", return_value=0),
     ):
         mock_validator = mock_vm_cls.return_value
 
@@ -564,7 +589,9 @@ def test_run_cli_uses_endpoint_loaded_from_config():
 
         mock_validator.validate_arguments.side_effect = _validate_arguments
         mock_validator.validate_transport.return_value = None
-        run_cli()
+        with pytest.raises(SystemExit) as exc:
+            run_cli()
+        assert exc.value.code == 0
 
 
 def test_run_cli_transport_error_exit(monkeypatch):
@@ -666,6 +693,44 @@ def test_run_cli_unexpected_error_debug(monkeypatch, caplog):
         with pytest.raises(SystemExit) as exc:
             run_cli()
         assert exc.value.code == 1
+
+
+def test_cli_fail_if_no_tools_blocked_exits_two(tmp_path):
+    import os
+    import subprocess
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[3]
+    out = tmp_path / "out"
+    out.mkdir()
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mcp_fuzzer",
+            "--mode",
+            "tools",
+            "--protocol",
+            "stdio",
+            "--endpoint",
+            "false",
+            "--runs",
+            "1",
+            "--timeout",
+            "5",
+            "--output-dir",
+            str(out),
+            "--fs-root",
+            str(out / ".mcp_fuzzer"),
+            "--fail-if-no-tools",
+        ],
+        cwd=root,
+        env={**os.environ, "PYTHONPATH": str(root)},
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+    assert (out / "run_summary.json").exists()
 
 
 def test_build_cli_config_uses_config_file(monkeypatch):

--- a/tests/unit/client/runtime/test_async_runner.py
+++ b/tests/unit/client/runtime/test_async_runner.py
@@ -196,16 +196,14 @@ def test_handle_cancellation_sets_exit(capsys):
     assert "Fuzzing interrupted" in capsys.readouterr().out
 
 
-def test_final_cleanup_restores_argv_and_exit():
+def test_final_cleanup_restores_argv():
     args = SimpleNamespace()
     runner = AsyncRunner(args, safety=SimpleNamespace())
     runner.loop = DummyLoop()
     runner.old_argv = ["old"]
     sys.argv = ["new"]
-    runner.should_exit = True
 
-    with pytest.raises(SystemExit):
-        runner._final_cleanup()
+    runner._final_cleanup()
 
     assert sys.argv == ["old"]
 
@@ -227,9 +225,7 @@ def test_run_handles_cancelled_error(monkeypatch):
     )
     monkeypatch.setattr(runner, "_cleanup_pending_tasks", lambda: None)
 
-    with pytest.raises(SystemExit):
-        runner.run(lambda: None, ["mcp-fuzzer"])
-
+    assert runner.run(lambda: None, ["mcp-fuzzer"]) == 130
     assert runner.should_exit is True
 
 
@@ -264,6 +260,7 @@ def test_execute_inner_client_handles_cancel(monkeypatch):
         enable_aiomonitor=False,
     )
     loop = asyncio.new_event_loop()
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
 
     def _run_until_complete(_):
         raise asyncio.CancelledError()
@@ -275,14 +272,10 @@ def test_execute_inner_client_handles_cancel(monkeypatch):
         patch.object(loop, "add_signal_handler"),
         patch.object(loop, "run_until_complete", side_effect=_run_until_complete),
     ):
-        try:
+        async def dummy():
+            return None
 
-            async def dummy():
-                return None
-
-            execute_inner_client(args, dummy, ["prog"])
-        except SystemExit as exc:
-            assert exc.code == 130
+        assert execute_inner_client(args, dummy, ["prog"]) == 130
     loop.close()
 
 
@@ -323,7 +316,5 @@ def test_run_with_retry_on_interrupt_exits_when_no_retry(monkeypatch):
         ),
         patch("mcp_fuzzer.cli.runtime.retry.Console") as mock_console,
     ):
-        with pytest.raises(SystemExit) as exc:
-            run_with_retry_on_interrupt(args, lambda: None, ["prog"])
-        assert exc.value.code == 130
+        assert run_with_retry_on_interrupt(args, lambda: None, ["prog"]) == 130
     mock_console.return_value.print.assert_called_once()

--- a/tests/unit/client/runtime/test_async_runner.py
+++ b/tests/unit/client/runtime/test_async_runner.py
@@ -6,9 +6,20 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from mcp_fuzzer.cli.runtime.async_runner import AsyncRunner, execute_inner_client
+from mcp_fuzzer.cli.runtime.async_runner import (
+    AsyncRunner,
+    _coerce_exit_code,
+    execute_inner_client,
+)
 from mcp_fuzzer.cli.runtime.retry import run_with_retry_on_interrupt
+from mcp_fuzzer.cli.exit_codes import GENERAL_ERROR, SUCCESS
 from mcp_fuzzer.client.safety import SafetyController
+
+
+def test_coerce_exit_code_rejects_non_int_results():
+    assert _coerce_exit_code(2) == 2
+    assert _coerce_exit_code(None) == SUCCESS
+    assert _coerce_exit_code("2") == GENERAL_ERROR
 
 
 def _make_aiomonitor():


### PR DESCRIPTION
## Summary
- Propagate `run_fuzz_app()` exit codes through `AsyncRunner` → `run_with_retry_on_interrupt` → `sys.exit()` in the CLI entrypoint
- Blocked runs with `--fail-if-no-tools` now exit **2** instead of silently exiting **0**, so CI jobs fail when no tools are discovered

## Test plan
- [x] `tox -e ruff`
- [x] `tox -e tests -- tests/unit/cli/test_cli.py tests/unit/client/runtime/test_async_runner.py tests/unit/cli/test_post_run.py`
- [x] Manual: `python -m mcp_fuzzer ... --fail-if-no-tools` with blocked stdio target returns exit code 2


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Exit Code Propagation Fix: Design Analysis

## Overview
This PR fixes a CLI behavior where fuzzing runs blocked due to `--fail-if-no-tools` previously exited “silently” with status code `0`. The change propagates the intended numeric exit code (notably `2` for “no tools available”) from the post-run stage up to the actual process exit status via `sys.exit(exit_code)`.

## Design Pattern Changes

### Chain of Responsibility / Pipeline propagation (now complete)
The execution pipeline previously discarded return values between layers; it now forwards them end-to-end:

```
run_fuzz_app()  (returns int from PostRunPresenter)
  ↓
AsyncRunner.run()  (returns int instead of None)
  ↓
execute_inner_client()  (returns int from runner)
  ↓
run_with_retry_on_interrupt()  (returns int from execute_inner_client)
  ↓
run_cli()  (captures return value and sys.exit(exit_code))
  ↓
Process exit code
```

### Process exit code model (new)
A dedicated exit-code module centralizes semantics:
- `SUCCESS = 0`
- `GENERAL_ERROR = 1`
- `NO_TOOLS_AVAILABLE = 2`
- `INTERRUPTED = 130`

This replaces ad-hoc numeric literals in the exit logic.

## Behavioral changes by component

### `mcp_fuzzer/cli/post_run.py`
`PostRunPresenter.present()` now returns:
- `NO_TOOLS_AVAILABLE` when no tools were discovered *and* `fail_if_no_tools` is enabled
- `SUCCESS` otherwise

### `mcp_fuzzer/cli/runtime/async_runner.py`
`AsyncRunner.run()` now returns `int` and normalizes the coroutine result:
- Uses a generic main coroutine return type (`Callable[[], Awaitable[_T]]`)
- `_coerce_exit_code()` converts the result to an `int` (returns it if already `int`, otherwise logs a warning and falls back to `SUCCESS`)
- Cancellation maps to `INTERRUPTED`

### `mcp_fuzzer/cli/runtime/retry.py`
`run_with_retry_on_interrupt()` now returns `int` instead of discarding outcomes:
- On `KeyboardInterrupt`, it retries once with the safety system enabled when configured
- Otherwise it returns `INTERRUPTED` (no longer raises/terminates immediately)

### `mcp_fuzzer/cli/entrypoint.py`
`run_cli()` now:
- captures `exit_code = run_with_retry_on_interrupt(...)`
- calls `sys.exit(exit_code)` so CI sees the intended non-zero exit

## SOLID Principle Analysis

### SRP (improved)
- `PostRunPresenter` is responsible for deriving the *exit code* from run results.
- `AsyncRunner` is responsible for async lifecycle, cleanup, and cancellation mapping.
- `retry.py` handles retry policy on interrupt.
- `entrypoint.py` handles CLI orchestration and turning outcomes into a process exit status.
This is more aligned with SRP than the prior “discarded return value” approach.

### OCP (good)
- `_coerce_exit_code()` provides a single normalization point if exit-code handling needs to evolve (e.g., stricter validation).
- Exit-code semantics are centralized in `exit_codes.py`.

### LSP (good)
- Changing `AsyncRunner.run()` from `-> None` to `-> int` better matches its effective contract (“what should the process exit with?”).
- The internal generic typing supports different coroutine return types while still enforcing an exit-code result at the boundary.

### ISP (minor concern)
- `AsyncRunner` depends on the concrete `SafetyController` type (not an abstraction). This is acceptable for an internal orchestration class, but it does slightly reduce substitutability for testing/mocking beyond lightweight injection.

### DIP (mixed but mostly acceptable)
- The pipeline supports dependency flow via optional `safety: SafetyController | None`.
- If `safety` is not provided, `execute_inner_client()` constructs a default controller, which is a minor DIP erosion. However, CLI code passes the controller through, so real usage stays consistent.

## Code/Design Smells & Recommendations

### 1) Silent coercion fallback in `_coerce_exit_code()` (risk: medium)
If the coroutine returns something other than `int`, the function logs a warning and returns `SUCCESS`.
- This can still mask programming mistakes (it will not crash, and the process will exit “successfully”).
**Recommendation:** consider failing closed (e.g., return `GENERAL_ERROR`) or enforce stricter runtime validation once the system stabilizes.

### 2) Inconsistent interrupt semantics at top-level (potential mismatch)
`AsyncRunner` maps cancellation to `INTERRUPTED (130)`, and `run_with_retry_on_interrupt()` returns `INTERRUPTED` when handling interrupts.
However, `run_cli()` still has:
- `except KeyboardInterrupt: ... sys.exit(0)`
**Recommendation:** align `run_cli()`’s top-level interrupt code with `INTERRUPTED` (130) for consistency and CI predictability.

### 3) Pytest vs production execution path divergence (test/prod difference)
`AsyncRunner.run()` uses `asyncio.run()` in pytest environments and a custom event loop in normal execution.
**Recommendation:** keep as-is if necessary for tests, but ensure behavior-equivalence is documented/covered (you appear to have done some of this via updated unit tests).

### 4) Multiple “exit decision” locations (now improved, but still spread)
Exit-code derivation occurs across:
- `PostRunPresenter` (no-tools vs success)
- `AsyncRunner` (cancellation -> interrupted)
- `entrypoint.py` (mapping errors/exceptions -> 1 / 0)
This is acceptable for an orchestration boundary, but it’s still “distributed control flow.”
**Recommendation:** keep the exit-code constants centralized (already done) and consider documenting the authoritative mapping table in one place.

## Testing/Verification Impact
- Updated unit tests to assert numeric return codes and propagation (rather than expecting `SystemExit`).
- Added/updated an integration-style CLI test that runs with `--fail-if-no-tools` and asserts exit code `2` and output summary creation.
This supports the new “return int all the way to sys.exit” design.

</final_summary>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->