### PR TITLE
Opt-in runtime-probe integration (mcpfz-probe sidecar)

### DIFF
--- a/mcp_fuzzer/client/tool_client_execution.py
+++ b/mcp_fuzzer/client/tool_client_execution.py
@@ -64,6 +64,9 @@ class ToolClientExecutionMixin:
         if auth_params:
             args_for_call.update(auth_params)
 
+        from ..runtime_probe import PROBE
+
+        probe_call_id = PROBE.begin(tool_name) if PROBE.enabled() else None
         try:
             result = await self._call_tool(
                 tool_name, args_for_call, tool_timeout=tool_timeout
@@ -138,6 +141,9 @@ class ToolClientExecutionMixin:
                 outcome=outcome,
                 crash=crash,
             )
+        finally:
+            if probe_call_id is not None:
+                PROBE.end(probe_call_id, tool_name)
 
         rss = self._sample_server_memory()
         if rss is not None:

--- a/mcp_fuzzer/orchestrator/session.py
+++ b/mcp_fuzzer/orchestrator/session.py
@@ -68,6 +68,18 @@ async def run_session(
             protocol_results=pr,
             build_transport_request=build_transport_request,
         )
+        # Merge runtime-probe findings (kernel-observed exec/net/fs during calls).
+        try:
+            from ..runtime_probe import PROBE
+
+            if PROBE.enabled():
+                runtime_findings = PROBE.drain_findings()
+                if runtime_findings:
+                    findings.extend(runtime_findings)
+                    findings_summary = summarize_findings(findings)
+                PROBE.stop()
+        except Exception as exc:
+            logging.warning("runtime probe finding merge failed: %s", exc)
         persist_session_findings(
             config,
             findings,

--- a/mcp_fuzzer/runtime_probe.py
+++ b/mcp_fuzzer/runtime_probe.py
@@ -1,0 +1,181 @@
+"""Optional runtime-probe integration for mcp-server-fuzzer.
+
+Bridges the fuzzer to the external ``mcpfz_probe`` sidecar so runtime behavior
+(process exec, and later network / file access) triggered by a tool call is
+captured by the kernel, attributed to that specific call, and turned into
+fuzzer ``Finding`` records.
+
+This is entirely opt-in. Every hook is a no-op unless ``MCP_FUZZER_RUNTIME_PROBE``
+is truthy *and* the ``mcpfz_probe`` package plus the sidecar binary are available,
+so the fuzzer's normal behavior is unchanged when it is off.
+
+Environment variables:
+  MCP_FUZZER_RUNTIME_PROBE=1              enable the probe
+  MCPFZ_PROBE_BIN=/path/to/mcpfz-probe   sidecar binary (default: "mcpfz-probe")
+  MCPFZ_PROBE_BACKEND=ebpf|fake          backend (default: "ebpf")
+  MCPFZ_PROBE_WORKSPACE=<dir>            policy workspace root (default: cwd)
+  MCPFZ_PROBE_TMPDIR=<dir>               policy tmp root (default: /tmp)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import uuid
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+def _truthy(value: str | None) -> bool:
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
+
+
+class _RuntimeProbe:
+    """Process-wide singleton coordinating the sidecar and finding collection."""
+
+    def __init__(self) -> None:
+        self._enabled = _truthy(os.environ.get("MCP_FUZZER_RUNTIME_PROBE"))
+        self._monitor: Any = None
+        self._policy: Any = None
+        self._lock = threading.Lock()
+        self._findings: list[Any] = []
+        self._run_counter: dict[str, int] = {}
+        self._generation = 0
+        self._started = False
+
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def ensure_started(self) -> None:
+        if not self._enabled or self._started:
+            return
+        with self._lock:
+            if self._started:
+                return
+            try:
+                from mcpfz_probe import RuntimePolicy, SidecarRuntimeMonitor
+            except Exception as exc:  # package not installed
+                log.warning("runtime probe disabled: cannot import mcpfz_probe: %s", exc)
+                self._enabled = False
+                return
+
+            binary = os.environ.get("MCPFZ_PROBE_BIN", "mcpfz-probe")
+            backend = os.environ.get("MCPFZ_PROBE_BACKEND", "ebpf")
+            raw = os.environ.get("MCPFZ_PROBE_RAW")
+            self._monitor = SidecarRuntimeMonitor(
+                command=[binary, "--backend", backend],
+                raw_path=Path(raw) if raw else None,
+            )
+            self._policy = RuntimePolicy(
+                workspace=Path(os.environ.get("MCPFZ_PROBE_WORKSPACE", os.getcwd())),
+                tmpdir=Path(os.environ.get("MCPFZ_PROBE_TMPDIR", "/tmp")),
+            )
+            try:
+                self._monitor.start()
+            except Exception as exc:
+                log.warning("runtime probe disabled: sidecar failed to start: %s", exc)
+                self._enabled = False
+                self._monitor = None
+                return
+            self._started = True
+            log.info("runtime probe: sidecar started (%s backend)", backend)
+
+    def set_scope(self, pid: int) -> None:
+        if not self._enabled or self._monitor is None:
+            return
+        try:
+            pgid = os.getpgid(pid)
+        except Exception:
+            pgid = pid
+        self._generation += 1
+        try:
+            self._monitor.set_scope_pgid(pgid, generation=self._generation)
+            log.info("runtime probe: scoped to pgid=%s gen=%s", pgid, self._generation)
+        except Exception as exc:
+            log.warning("runtime probe: set_scope failed: %s", exc)
+
+    def begin(self, tool_name: str) -> str | None:
+        if not self._enabled or self._monitor is None:
+            return None
+        call_id = uuid.uuid4().hex
+        try:
+            self._monitor.begin_call(call_id, tool_name)
+        except Exception as exc:
+            log.warning("runtime probe: begin_call failed: %s", exc)
+            return None
+        return call_id
+
+    def end(self, call_id: str | None, tool_name: str) -> None:
+        if not self._enabled or self._monitor is None or call_id is None:
+            return
+        try:
+            from mcpfz_probe import evaluate_events
+
+            summary = self._monitor.end_call(call_id)
+            drafts = evaluate_events(summary.events, self._policy)
+        except Exception as exc:
+            log.warning("runtime probe: end_call failed: %s", exc)
+            return
+        if not drafts:
+            return
+        run = self._run_counter.get(tool_name, 0)
+        self._run_counter[tool_name] = run + 1
+        findings = [self._to_finding(d, tool_name, run) for d in drafts]
+        with self._lock:
+            self._findings.extend(findings)
+
+    def drain_findings(self) -> list[Any]:
+        """Return accumulated per-call findings plus any ambient runtime findings."""
+        self._collect_ambient()
+        with self._lock:
+            out = self._findings
+            self._findings = []
+        return out
+
+    def stop(self) -> None:
+        monitor, self._monitor, self._started = self._monitor, None, False
+        if monitor is not None:
+            try:
+                monitor.stop()
+            except Exception:
+                pass
+
+    def _collect_ambient(self) -> None:
+        """Runtime activity outside any call window (delayed exfil/persistence)."""
+        if not self._enabled or self._monitor is None:
+            return
+        try:
+            from mcpfz_probe import evaluate_events
+
+            ambient = self._monitor.ambient_events()
+            drafts = evaluate_events(ambient, self._policy)
+        except Exception:
+            return
+        findings = [self._to_finding(d, "<ambient>", None) for d in drafts]
+        if findings:
+            with self._lock:
+                self._findings.extend(findings)
+
+    @staticmethod
+    def _to_finding(draft: Any, target: str, run: int | None) -> Any:
+        from mcp_fuzzer.diagnostics.model import Finding
+
+        evidence = dict(getattr(draft, "evidence", {}) or {})
+        evidence["source"] = "mcpfz-probe"
+        return Finding(
+            category=draft.category,
+            severity=draft.severity,
+            kind="tool",
+            target=target,
+            run=run,
+            detail=draft.detail,
+            evidence=evidence,
+        )
+
+
+PROBE = _RuntimeProbe()
+
+__all__ = ["PROBE"]

--- a/mcp_fuzzer/transport/drivers/stdio_driver.py
+++ b/mcp_fuzzer/transport/drivers/stdio_driver.py
@@ -219,6 +219,16 @@ class StdioDriver(TransportDriver):
                         self._get_activity_timestamp,
                     )
 
+                # Scope the optional runtime probe to the server's process group.
+                try:
+                    from ...runtime_probe import PROBE
+
+                    if PROBE.enabled():
+                        PROBE.ensure_started()
+                        PROBE.set_scope(self.process.pid)
+                except Exception as exc:  # never let the probe break a run
+                    logging.warning("runtime probe scope hook failed: %s", exc)
+
                 self._initialized = True
                 self._mcp_initialized = False
                 await self._update_activity()


### PR DESCRIPTION
Adds an opt-in bridge to the external [mcpfz-probe](https://github.com/Agent-Hellboy/mcpfz-probe) runtime sidecar, so behavior a tool call triggers at runtime (process exec today; network/file next) is captured by the kernel, attributed to that specific call, and surfaced as fuzzer `Finding`s.

## How it works

New module `mcp_fuzzer/runtime_probe.py` exposes a process-wide `PROBE` singleton. Three small hooks:

1. **`transport/drivers/stdio_driver.py`** — on stdio server launch, scope the sidecar to the server's process group.
2. **`client/tool_client_execution.py`** — `begin`/`end` marks around each `_execute_tool_call`.
3. **`orchestrator/session.py`** — merge runtime findings into the session and stop the probe.

Policy drafts from the sidecar are converted into `diagnostics.model.Finding` (kind `tool`, with `category`/`severity`/`target`/`run`/`detail`/`evidence`), so they flow through the normal persistence and reporting path.

## Fully opt-in

Every hook is a no-op unless `MCP_FUZZER_RUNTIME_PROBE` is truthy **and** the `mcpfz_probe` package + sidecar binary are available. With it unset, fuzzer behavior is unchanged (verified: identical run, 0 runtime findings, no probe activity).

```sh
export MCP_FUZZER_RUNTIME_PROBE=1
export MCPFZ_PROBE_BIN=/path/to/mcpfz-probe
export MCPFZ_PROBE_BACKEND=ebpf            # or "fake"
sudo -E mcp-fuzzer --mode tools --protocol stdio \
  --endpoint "python examples/vulnerable_server.py" --runs 3 --max-concurrency 1
```

## Verified

On Ubuntu 24.04 / kernel 6.8, fuzzing a deliberately-vulnerable stdio server (a tool that shells out) with the eBPF backend: every fuzzed `fetch_url` call's `/bin/sh` and `curl` execs were captured by the kernel, attributed to the exact tool + run, flagged `high` `runtime.exec`, and merged into `findings.json`.

## Note
Per-call attribution assumes serialized stdio calls (`--max-concurrency 1`); execs from overlapping calls are still caught but land in the `ambient` bucket. Env vars: `MCP_FUZZER_RUNTIME_PROBE`, `MCPFZ_PROBE_BIN`, `MCPFZ_PROBE_BACKEND`, `MCPFZ_PROBE_WORKSPACE`, `MCPFZ_PROBE_TMPDIR`, `MCPFZ_PROBE_RAW`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)