### PR TITLE
Fix runtime_probe lint + document mcpfz-probe integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,37 @@ mcp-fuzzer --mode tools --protocol stdio --endpoint "python my_server.py" \
 More runnable example flows are documented in
 [`examples/README.md`](examples/README.md).
 
+## Runtime monitoring (optional)
+
+Pair the fuzzer with [**mcpfz-probe**](https://github.com/Agent-Hellboy/mcpfz-probe),
+a runtime sidecar that watches what a tool call actually does at the kernel level
+(process exec, network connect/send, file open/delete, chmod, ptrace) and reports
+anything suspicious as findings attributed to the exact tool call.
+
+Fetch the released Linux binary from mcpfz-probe and point the fuzzer at it:
+
+```bash
+# Latest eBPF-enabled Linux build (built and published by mcpfz-probe CI)
+curl -L -o mcpfz-probe \
+  https://github.com/Agent-Hellboy/mcpfz-probe/releases/latest/download/mcpfz-probe-x86_64-linux-ebpf
+chmod +x mcpfz-probe
+
+pip install mcpfz-probe   # the Python monitor package (or install from source)
+
+export MCP_FUZZER_RUNTIME_PROBE=1
+export MCPFZ_PROBE_BIN="$PWD/mcpfz-probe"
+export MCPFZ_PROBE_BACKEND=ebpf          # Linux + root/CAP_BPF; use "fake" elsewhere
+sudo -E mcp-fuzzer --mode tools --protocol stdio \
+  --endpoint "python my_server.py" --runs 3 --max-concurrency 1
+```
+
+Runtime findings (`runtime.exec`, `runtime.net_connect`, `runtime.sensitive_read`,
+`runtime.fs_write`, `runtime.fs_delete`, `runtime.fs_chmod`, `runtime.ptrace`) are
+merged into the normal report. The hooks are no-ops unless
+`MCP_FUZZER_RUNTIME_PROBE` is set, so default behavior is unchanged. See the
+[mcpfz-probe README](https://github.com/Agent-Hellboy/mcpfz-probe#readme) for the
+backend/build details.
+
 ## Documentation
 
 Keep the README for the basics. Use the docs for everything else:

--- a/mcp_fuzzer/runtime_probe.py
+++ b/mcp_fuzzer/runtime_probe.py
@@ -58,7 +58,7 @@ class _RuntimeProbe:
             try:
                 from mcpfz_probe import RuntimePolicy, SidecarRuntimeMonitor
             except Exception as exc:  # package not installed
-                log.warning("runtime probe disabled: cannot import mcpfz_probe: %s", exc)
+                log.warning("runtime probe: mcpfz_probe import failed: %s", exc)
                 self._enabled = False
                 return
 


### PR DESCRIPTION
- Fix ruff `E501` (over-long log line) in `mcp_fuzzer/runtime_probe.py`.
- Add a **Runtime monitoring** section to the README linking to [mcpfz-probe](https://github.com/Agent-Hellboy/mcpfz-probe), with instructions to fetch the released Linux binary and enable the probe (`MCP_FUZZER_RUNTIME_PROBE` / `MCPFZ_PROBE_BIN`).

`ruff check mcp_fuzzer tests` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)