### PR TITLE
Bump version to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-07-04
+
+### Added
+
+- Opt-in runtime-probe integration with
+  [mcpfz-probe](https://github.com/Agent-Hellboy/mcpfz-probe): scope the sidecar
+  to the stdio server's process group, mark begin/end around each tool call, and
+  merge kernel-observed runtime findings (`runtime.exec`, `runtime.net_connect`,
+  `runtime.sensitive_read`, `runtime.fs_write`, `runtime.fs_delete`,
+  `runtime.fs_chmod`, `runtime.ptrace`) into the report. Enabled via
+  `MCP_FUZZER_RUNTIME_PROBE`; a no-op when unset. See the README
+  "Runtime monitoring" section.
+
 ## [0.4.0] - 2026-06-18
 
 ### Added

--- a/mcp_fuzzer/version.py
+++ b/mcp_fuzzer/version.py
@@ -1,3 +1,3 @@
-VERSION = "0.4.0"
+VERSION = "0.4.2"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
Release 0.4.2 — ships the opt-in [mcpfz-probe](https://github.com/Agent-Hellboy/mcpfz-probe) runtime-monitoring integration. CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Bumped the project version from **0.4.0** to **0.4.2**.
- Added the **0.4.2** release notes to `CHANGELOG.md`.
- Documented the opt-in `mcpfz-probe` runtime-monitoring integration, gated by `MCP_FUZZER_RUNTIME_PROBE` and inactive when unset.

### Design / patterns
- Uses an **opt-in feature flag** pattern for runtime monitoring, keeping the integration decoupled from the default execution path.
- The probe is scoped to the **stdio server process group** and wraps each tool call with begin/end markers, which aligns with an **observability wrapper** approach.

### SOLID / smells
- **SOLID:** No apparent violations from the version/changelog changes; the feature remains isolated and configurable.
- **Smells:** Minimal. The only notable risk is potential added coupling to runtime reporting if probe findings are merged too broadly, but this is mitigated by the gating flag and explicit scoping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->