### PR TITLE
Add mcpfz-probe optional-dependency extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ curl -L -o mcpfz-probe \
   https://github.com/Agent-Hellboy/mcpfz-probe/releases/latest/download/mcpfz-probe-x86_64-linux-ebpf
 chmod +x mcpfz-probe
 
-pip install mcpfz-probe   # the Python monitor package (or install from source)
+pip install "mcp-fuzzer[mcpfz-probe]"   # pulls in the Python monitor package
 
 export MCP_FUZZER_RUNTIME_PROBE=1
 export MCPFZ_PROBE_BIN="$PWD/mcpfz-probe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Runtime monitoring via the mcpfz-probe sidecar (Linux eBPF / portable fake).
+mcpfz-probe = ["mcpfz-probe>=0.1.0"]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",


### PR DESCRIPTION
Declares a `mcpfz-probe` extra so `pip install mcp-fuzzer[mcpfz-probe]` installs the runtime monitor package. README's Runtime monitoring section updated to use it.

Resolves the extra once `mcpfz-probe` is published to PyPI (see mcpfz-probe#4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)