### PR TITLE
Bump version to 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-07-05
+
+### Added
+
+- `mcpfz-probe` optional-dependency extra: `pip install "mcp-fuzzer[mcpfz-probe]"`
+  installs the runtime monitor package.
+
 ## [0.4.2] - 2026-07-04
 
 ### Added

--- a/mcp_fuzzer/version.py
+++ b/mcp_fuzzer/version.py
@@ -1,3 +1,3 @@
-VERSION = "0.4.2"
+VERSION = "0.4.3"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
Release 0.4.3 — ships the `mcp-fuzzer[mcpfz-probe]` extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the project to version `0.4.3` and documented the new `mcpfz-probe` extra in the changelog, which installs the runtime monitor package via `pip install "mcp-fuzzer[mcpfz-probe]"`.

Design-wise, this is a release/versioning change rather than a functional architecture change. It follows the existing simple constant-based versioning pattern in `mcp_fuzzer/version.py` and keeps the public API surface unchanged. SOLID impact is minimal and effectively neutral here, since no business logic or module responsibilities were altered. No notable code smells or design regressions are introduced by these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->